### PR TITLE
Add soft delete support for test cases

### DIFF
--- a/initdb/create_tables.sql
+++ b/initdb/create_tables.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS test_cases (
     model_settings JSONB,
     system_prompt TEXT NOT NULL,
     last_user_message TEXT NOT NULL,
+    is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
@@ -39,6 +40,7 @@ CREATE TABLE IF NOT EXISTS test_logs (
 -- Indexes for better query performance
 CREATE INDEX IF NOT EXISTS idx_test_cases_name ON test_cases(name);
 CREATE INDEX IF NOT EXISTS idx_test_cases_created_at ON test_cases(created_at);
+CREATE INDEX IF NOT EXISTS idx_test_cases_is_deleted ON test_cases(is_deleted);
 CREATE INDEX IF NOT EXISTS idx_test_logs_test_case_id ON test_logs(test_case_id);
 CREATE INDEX IF NOT EXISTS idx_test_logs_status ON test_logs(status);
 CREATE INDEX IF NOT EXISTS idx_test_logs_created_at ON test_logs(created_at);
@@ -54,6 +56,7 @@ COMMENT ON COLUMN test_cases.model_name IS 'Model name used in original request'
 COMMENT ON COLUMN test_cases.model_settings IS 'Model settings JSON (temperature, max_tokens, top_p, etc.) from original LLM request';
 COMMENT ON COLUMN test_cases.system_prompt IS 'Extracted system prompt for display and replay';
 COMMENT ON COLUMN test_cases.last_user_message IS 'Extracted last user message for display and replay';
+COMMENT ON COLUMN test_cases.is_deleted IS 'Soft delete flag to hide test cases from listings without removing history';
 
 COMMENT ON COLUMN test_logs.system_prompt IS 'Actual system prompt used in execution (may be modified)';
 COMMENT ON COLUMN test_logs.user_message IS 'Actual user message used in execution (may be modified)';

--- a/migrations/004_add_is_deleted_to_test_cases.sql
+++ b/migrations/004_add_is_deleted_to_test_cases.sql
@@ -1,0 +1,16 @@
+-- Migration: Add soft delete support to test cases
+-- Date: 2025-03-10
+-- Description: Adds an is_deleted flag to test_cases to support soft deletion and keeps historical records.
+
+-- Step 1: Add is_deleted column with default false
+ALTER TABLE test_cases
+    ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE NOT NULL;
+
+-- Step 2: Ensure existing rows are set to false (defensive)
+UPDATE test_cases SET is_deleted = FALSE WHERE is_deleted IS NULL;
+
+-- Step 3: Create index to optimize queries filtering on the flag
+CREATE INDEX IF NOT EXISTS idx_test_cases_is_deleted ON test_cases(is_deleted);
+
+-- Step 4: Document the new column
+COMMENT ON COLUMN test_cases.is_deleted IS 'Soft delete flag to hide test cases from listings without removing history';

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -5,6 +5,9 @@ This directory contains database migration files for the LLM Replay System.
 ## Migration Files
 
 - `001_add_temperature_column.sql` - Adds temperature parameter support to test_cases table
+- `002_add_temperature_to_test_logs.sql` - Mirrors temperature support in test_logs
+- `003_replace_temperature_with_model_settings.sql` - Replaces temperature columns with model_settings JSON fields
+- `004_add_is_deleted_to_test_cases.sql` - Introduces soft delete flag for test cases
 
 ## How to Apply Migrations
 
@@ -43,4 +46,4 @@ Migration files should follow the pattern: `{version}_{description}.sql`
 
 ## Current Schema Version
 
-After applying all migrations, your database should be at version: **001**
+After applying all migrations, your database should be at version: **004**

--- a/src/api/v1/converters/test_case_converters.py
+++ b/src/api/v1/converters/test_case_converters.py
@@ -42,6 +42,7 @@ def convert_test_case_data_to_response(data: TestCaseData) -> TestCaseResponse:
         model_settings=data.model_settings,
         system_prompt=data.system_prompt,
         last_user_message=data.last_user_message,
+        is_deleted=data.is_deleted,
         created_at=data.created_at,
         updated_at=data.updated_at
     )

--- a/src/api/v1/schemas/responses/test_case_responses.py
+++ b/src/api/v1/schemas/responses/test_case_responses.py
@@ -23,6 +23,7 @@ class TestCaseResponse(BaseModel):
     model_settings: Optional[Dict] = Field(None, description="Model settings JSON (temperature, max_tokens, etc.)")
     system_prompt: str = Field(..., description="System prompt")
     last_user_message: str = Field(..., description="Last user message")
+    is_deleted: bool = Field(False, description="Indicates whether the test case is soft deleted")
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
     

--- a/src/models/test_case.py
+++ b/src/models/test_case.py
@@ -6,7 +6,7 @@ Data model for LLM test cases in the replay system.
 
 from typing import List, Optional
 
-from sqlalchemy import JSON, String, Text, Float
+from sqlalchemy import Boolean, JSON, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import BaseDBModel
@@ -41,6 +41,13 @@ class TestCase(BaseDBModel):
     # Parsed key components for display and replay
     system_prompt: Mapped[str] = mapped_column(Text, nullable=False)
     last_user_message: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Soft delete flag
+    is_deleted: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False
+    )
     
     # Relationships
     test_logs: Mapped[List["TestLog"]] = relationship(

--- a/tests/test_test_case_service.py
+++ b/tests/test_test_case_service.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from src.services.test_case_service import TestCaseService, TestCaseUpdateData
+
+
+TestCaseService.__test__ = False
+TestCaseUpdateData.__test__ = False
+
+
+def _build_test_case(**overrides):
+    base = {
+        "id": "case-1",
+        "name": "Sample",
+        "description": "desc",
+        "raw_data": {"messages": []},
+        "middle_messages": [],
+        "tools": None,
+        "model_name": "gpt",
+        "model_settings": {"temperature": 0.2},
+        "system_prompt": "system",
+        "last_user_message": "user",
+        "is_deleted": False,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_get_test_case_includes_soft_delete_flag(monkeypatch):
+    service = TestCaseService()
+    deleted_case = _build_test_case(is_deleted=True)
+    call_args = {}
+
+    def _fake_get_by_id(case_id, include_deleted=False):
+        call_args["case_id"] = case_id
+        call_args["include_deleted"] = include_deleted
+        return deleted_case
+
+    monkeypatch.setattr(service.store, "get_by_id", _fake_get_by_id)
+
+    result = service.get_test_case("case-1")
+
+    assert result is not None
+    assert result.is_deleted is True
+    assert call_args == {"case_id": "case-1", "include_deleted": True}
+
+
+def test_update_test_case_blocks_deleted_records(monkeypatch):
+    service = TestCaseService()
+    deleted_case = _build_test_case(is_deleted=True)
+
+    monkeypatch.setattr(
+        service.store,
+        "get_by_id",
+        lambda _case_id, include_deleted=False: deleted_case,
+    )
+
+    update_called = {"value": False}
+
+    def _fake_update(test_case):
+        update_called["value"] = True
+        return test_case
+
+    monkeypatch.setattr(service.store, "update", _fake_update)
+
+    result = service.update_test_case("case-1", TestCaseUpdateData(name="Updated"))
+
+    assert result is None
+    assert update_called["value"] is False


### PR DESCRIPTION
## Summary
- add an `is_deleted` flag to test cases and surface it through the service layer and API responses
- update data access logic to mark records as deleted, filter them from listings, prevent updates/execution of deleted cases, and allow detail views to fetch archived entries on demand
- ship a migration/init script update and new unit tests to cover the soft-delete behavior
- extend the service tests to assert the include-deleted retrieval path used by the detail endpoint

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ce94ab6bfc833399a809449cafa181