### PR TITLE
Add agent and regression test support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ENV_FILE := .env
 ENV_SAMPLE := env.sample
 
 # Directories
-SRC_DIR := $(PACKAGE_NAME)
+SRC_DIR := src
 TESTS_DIR := tests
 LOGS_DIR := logs
 

--- a/initdb/create_tables.sql
+++ b/initdb/create_tables.sql
@@ -3,9 +3,41 @@
 -- This file contains the SQL DDL for creating the database tables
 -- for the LLM test replay system.
 
+-- Agents table
+CREATE TABLE IF NOT EXISTS agents (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    default_model_name VARCHAR(255),
+    default_system_prompt TEXT,
+    default_model_settings JSONB,
+    is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+-- Regression tests table
+CREATE TABLE IF NOT EXISTS regression_tests (
+    id VARCHAR(255) PRIMARY KEY,
+    agent_id VARCHAR(255) NOT NULL REFERENCES agents(id),
+    status VARCHAR(32) DEFAULT 'pending' NOT NULL,
+    model_name_override VARCHAR(255) NOT NULL,
+    system_prompt_override TEXT NOT NULL,
+    model_settings_override JSONB NOT NULL,
+    total_count INTEGER DEFAULT 0 NOT NULL,
+    success_count INTEGER DEFAULT 0 NOT NULL,
+    failed_count INTEGER DEFAULT 0 NOT NULL,
+    error_message TEXT,
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
 -- Test cases table
 CREATE TABLE IF NOT EXISTS test_cases (
     id VARCHAR(255) PRIMARY KEY,
+    agent_id VARCHAR(255) NOT NULL REFERENCES agents(id),
     name VARCHAR(255) NOT NULL,
     description TEXT,
     raw_data JSONB NOT NULL,
@@ -24,6 +56,8 @@ CREATE TABLE IF NOT EXISTS test_cases (
 CREATE TABLE IF NOT EXISTS test_logs (
     id VARCHAR(255) PRIMARY KEY,
     test_case_id VARCHAR(255) NOT NULL REFERENCES test_cases(id) ON DELETE CASCADE,
+    agent_id VARCHAR(255) NOT NULL REFERENCES agents(id),
+    regression_test_id VARCHAR(255) REFERENCES regression_tests(id),
     model_name VARCHAR(100) NOT NULL,
     model_settings JSONB,
     system_prompt TEXT NOT NULL,
@@ -41,14 +75,24 @@ CREATE TABLE IF NOT EXISTS test_logs (
 CREATE INDEX IF NOT EXISTS idx_test_cases_name ON test_cases(name);
 CREATE INDEX IF NOT EXISTS idx_test_cases_created_at ON test_cases(created_at);
 CREATE INDEX IF NOT EXISTS idx_test_cases_is_deleted ON test_cases(is_deleted);
+CREATE INDEX IF NOT EXISTS idx_test_cases_agent_id ON test_cases(agent_id);
 CREATE INDEX IF NOT EXISTS idx_test_logs_test_case_id ON test_logs(test_case_id);
 CREATE INDEX IF NOT EXISTS idx_test_logs_status ON test_logs(status);
 CREATE INDEX IF NOT EXISTS idx_test_logs_created_at ON test_logs(created_at);
+CREATE INDEX IF NOT EXISTS idx_test_logs_agent_id ON test_logs(agent_id);
+CREATE INDEX IF NOT EXISTS idx_test_logs_regression_test_id ON test_logs(regression_test_id);
+CREATE INDEX IF NOT EXISTS idx_regression_tests_agent_id ON regression_tests(agent_id);
+CREATE INDEX IF NOT EXISTS idx_regression_tests_status ON regression_tests(status);
 
 -- Comments for documentation
+COMMENT ON TABLE agents IS 'Stores logical agents that own test cases and defaults.';
 COMMENT ON TABLE test_cases IS 'Stores LLM test cases with original and parsed data for replay';
 COMMENT ON TABLE test_logs IS 'Stores execution logs and results for LLM test runs';
+COMMENT ON TABLE regression_tests IS 'Stores regression execution metadata for an agent';
 
+COMMENT ON COLUMN agents.is_deleted IS 'Soft delete flag to hide agents without removing history';
+COMMENT ON COLUMN regression_tests.status IS 'Execution status: pending, running, completed, or failed';
+COMMENT ON COLUMN regression_tests.model_settings_override IS 'Model settings JSON applied to the regression execution';
 COMMENT ON COLUMN test_cases.raw_data IS 'Original logfire raw data for audit purposes';
 COMMENT ON COLUMN test_cases.middle_messages IS 'Messages except system prompt and last user message';
 COMMENT ON COLUMN test_cases.tools IS 'Tools definition from the request';
@@ -57,6 +101,7 @@ COMMENT ON COLUMN test_cases.model_settings IS 'Model settings JSON (temperature
 COMMENT ON COLUMN test_cases.system_prompt IS 'Extracted system prompt for display and replay';
 COMMENT ON COLUMN test_cases.last_user_message IS 'Extracted last user message for display and replay';
 COMMENT ON COLUMN test_cases.is_deleted IS 'Soft delete flag to hide test cases from listings without removing history';
+COMMENT ON COLUMN test_cases.agent_id IS 'Owning agent for this test case';
 
 COMMENT ON COLUMN test_logs.system_prompt IS 'Actual system prompt used in execution (may be modified)';
 COMMENT ON COLUMN test_logs.user_message IS 'Actual user message used in execution (may be modified)';
@@ -64,3 +109,5 @@ COMMENT ON COLUMN test_logs.model_settings IS 'Model settings JSON (temperature,
 COMMENT ON COLUMN test_logs.tools IS 'Actual tools used in execution (may be modified)';
 COMMENT ON COLUMN test_logs.status IS 'Execution status: success or failed';
 COMMENT ON COLUMN test_logs.response_time_ms IS 'Response time in milliseconds';
+COMMENT ON COLUMN test_logs.agent_id IS 'Agent associated with the executed test case';
+COMMENT ON COLUMN test_logs.regression_test_id IS 'Regression test run that generated this log';

--- a/initdb/create_tables.sql
+++ b/initdb/create_tables.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS regression_tests (
     error_message TEXT,
     started_at TIMESTAMP,
     completed_at TIMESTAMP,
+    is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
@@ -83,6 +84,7 @@ CREATE INDEX IF NOT EXISTS idx_test_logs_agent_id ON test_logs(agent_id);
 CREATE INDEX IF NOT EXISTS idx_test_logs_regression_test_id ON test_logs(regression_test_id);
 CREATE INDEX IF NOT EXISTS idx_regression_tests_agent_id ON regression_tests(agent_id);
 CREATE INDEX IF NOT EXISTS idx_regression_tests_status ON regression_tests(status);
+CREATE INDEX IF NOT EXISTS idx_regression_tests_is_deleted ON regression_tests(is_deleted);
 
 -- Comments for documentation
 COMMENT ON TABLE agents IS 'Stores logical agents that own test cases and defaults.';
@@ -93,6 +95,7 @@ COMMENT ON TABLE regression_tests IS 'Stores regression execution metadata for a
 COMMENT ON COLUMN agents.is_deleted IS 'Soft delete flag to hide agents without removing history';
 COMMENT ON COLUMN regression_tests.status IS 'Execution status: pending, running, completed, or failed';
 COMMENT ON COLUMN regression_tests.model_settings_override IS 'Model settings JSON applied to the regression execution';
+COMMENT ON COLUMN regression_tests.is_deleted IS 'Soft delete flag to hide regression tests without hard deleting.';
 COMMENT ON COLUMN test_cases.raw_data IS 'Original logfire raw data for audit purposes';
 COMMENT ON COLUMN test_cases.middle_messages IS 'Messages except system prompt and last user message';
 COMMENT ON COLUMN test_cases.tools IS 'Tools definition from the request';

--- a/main.py
+++ b/main.py
@@ -75,9 +75,7 @@ async def run_cli_mode() -> None:
                 print(
                     f"🤖 Demo Agent: You said '{user_input}'. This is where your agent logic would go!"
                 )
-                print(
-                    "   💡 Tip: Implement your agent in replay_llm_call/agents/"
-                )
+                print("   💡 Tip: Implement your agent in replay_llm_call/agents/")
                 print()
             else:
                 print("Please enter a command or message.")

--- a/migrations/005_add_agents_and_regression_tests.sql
+++ b/migrations/005_add_agents_and_regression_tests.sql
@@ -1,0 +1,86 @@
+-- Migration: introduce agents and regression tests
+-- Date: 2025-03-18
+-- Description: Adds agents table, regression test tracking, and associates existing
+--              test cases/logs with a default agent.
+
+-- Step 1: Create agents table if it does not exist
+CREATE TABLE IF NOT EXISTS agents (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    default_model_name VARCHAR(255),
+    default_system_prompt TEXT,
+    default_model_settings JSONB,
+    is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+-- Step 2: Ensure a default agent exists for legacy data
+INSERT INTO agents (id, name, description)
+VALUES ('default-agent', 'Default Agent', 'System generated default agent for legacy test cases')
+ON CONFLICT (id) DO NOTHING;
+
+-- Step 3: Create regression_tests table
+CREATE TABLE IF NOT EXISTS regression_tests (
+    id VARCHAR(255) PRIMARY KEY,
+    agent_id VARCHAR(255) NOT NULL REFERENCES agents(id),
+    status VARCHAR(32) DEFAULT 'pending' NOT NULL,
+    model_name_override VARCHAR(255) NOT NULL,
+    system_prompt_override TEXT NOT NULL,
+    model_settings_override JSONB NOT NULL,
+    total_count INTEGER DEFAULT 0 NOT NULL,
+    success_count INTEGER DEFAULT 0 NOT NULL,
+    failed_count INTEGER DEFAULT 0 NOT NULL,
+    error_message TEXT,
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+-- Step 4: Add agent_id to test_cases and backfill existing rows
+ALTER TABLE test_cases
+    ADD COLUMN IF NOT EXISTS agent_id VARCHAR(255);
+
+UPDATE test_cases SET agent_id = 'default-agent' WHERE agent_id IS NULL;
+
+ALTER TABLE test_cases
+    ALTER COLUMN agent_id SET NOT NULL;
+
+ALTER TABLE test_cases
+    ADD CONSTRAINT fk_test_cases_agent
+    FOREIGN KEY (agent_id) REFERENCES agents(id);
+
+CREATE INDEX IF NOT EXISTS idx_test_cases_agent_id ON test_cases(agent_id);
+
+-- Step 5: Add agent linkage to test_logs and optional regression pointer
+ALTER TABLE test_logs
+    ADD COLUMN IF NOT EXISTS agent_id VARCHAR(255);
+
+UPDATE test_logs SET agent_id = 'default-agent' WHERE agent_id IS NULL;
+
+ALTER TABLE test_logs
+    ALTER COLUMN agent_id SET NOT NULL;
+
+ALTER TABLE test_logs
+    ADD CONSTRAINT fk_test_logs_agent
+    FOREIGN KEY (agent_id) REFERENCES agents(id);
+
+ALTER TABLE test_logs
+    ADD COLUMN IF NOT EXISTS regression_test_id VARCHAR(255);
+
+ALTER TABLE test_logs
+    ADD CONSTRAINT fk_test_logs_regression
+    FOREIGN KEY (regression_test_id) REFERENCES regression_tests(id);
+
+CREATE INDEX IF NOT EXISTS idx_test_logs_agent_id ON test_logs(agent_id);
+CREATE INDEX IF NOT EXISTS idx_test_logs_regression_test_id ON test_logs(regression_test_id);
+CREATE INDEX IF NOT EXISTS idx_regression_tests_agent_id ON regression_tests(agent_id);
+CREATE INDEX IF NOT EXISTS idx_regression_tests_status ON regression_tests(status);
+
+-- Step 6: Document new columns (optional but helps introspection)
+COMMENT ON COLUMN test_cases.agent_id IS 'Owning agent for this test case';
+COMMENT ON COLUMN test_logs.agent_id IS 'Agent associated with the executed test case';
+COMMENT ON COLUMN test_logs.regression_test_id IS 'Regression test run that generated this log';
+COMMENT ON TABLE regression_tests IS 'Stores regression execution metadata for an agent';

--- a/migrations/006_add_is_deleted_to_regression_tests.sql
+++ b/migrations/006_add_is_deleted_to_regression_tests.sql
@@ -1,0 +1,12 @@
+-- Migration: add soft delete flag to regression tests
+-- Date: 2025-03-25
+-- Description: Introduces an is_deleted column to regression_tests so that
+--              agent deletions can cascade without permanently removing rows.
+
+ALTER TABLE regression_tests
+    ADD COLUMN IF NOT EXISTS is_deleted BOOLEAN DEFAULT FALSE NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_regression_tests_is_deleted
+    ON regression_tests (is_deleted);
+
+COMMENT ON COLUMN regression_tests.is_deleted IS 'Soft delete flag to hide regression tests without hard deleting.';

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -8,6 +8,8 @@ This directory contains database migration files for the LLM Replay System.
 - `002_add_temperature_to_test_logs.sql` - Mirrors temperature support in test_logs
 - `003_replace_temperature_with_model_settings.sql` - Replaces temperature columns with model_settings JSON fields
 - `004_add_is_deleted_to_test_cases.sql` - Introduces soft delete flag for test cases
+- `005_add_agents_and_regression_tests.sql` - Adds agent entities and regression test tracking tables
+- `006_add_is_deleted_to_regression_tests.sql` - Adds soft delete flag for regression tests
 
 ## How to Apply Migrations
 
@@ -46,4 +48,4 @@ Migration files should follow the pattern: `{version}_{description}.sql`
 
 ## Current Schema Version
 
-After applying all migrations, your database should be at version: **004**
+After applying all migrations, your database should be at version: **006**

--- a/scripts/test_temperature_feature.py
+++ b/scripts/test_temperature_feature.py
@@ -72,7 +72,13 @@ def test_database_storage():
     try:
         service = TestCaseService()
         agent_service = AgentService()
-        default_agent = agent_service.ensure_default_agent_exists()
+        agents = agent_service.list_agents()
+        if not agents:
+            logger.warning(
+                "Skipping database storage test: no agents available"
+            )
+            return True
+        default_agent = agents[0]
         
         # Test data with temperature
         raw_data = {

--- a/scripts/test_temperature_feature.py
+++ b/scripts/test_temperature_feature.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(project_root))
 
 from src.core.logger import get_logger
 from src.services.llm_parser_service import parse_llm_raw_data
+from src.services.agent_service import AgentService
 from src.services.test_case_service import TestCaseService, TestCaseCreateData
 from src.stores.database import test_connection
 
@@ -70,6 +71,8 @@ def test_database_storage():
     
     try:
         service = TestCaseService()
+        agent_service = AgentService()
+        default_agent = agent_service.ensure_default_agent_exists()
         
         # Test data with temperature
         raw_data = {
@@ -89,20 +92,23 @@ def test_database_storage():
         create_request = TestCaseCreateData(
             name="Temperature Test Case",
             raw_data=raw_data,
-            description="Test case for temperature feature"
+            description="Test case for temperature feature",
+            agent_id=default_agent.id,
         )
         
         created_case = service.create_test_case(create_request)
         logger.info(f"✓ Test case created with ID: {created_case.id}")
         
         # Verify temperature was stored
-        assert created_case.temperature == 0.3, f"Expected 0.3, got {created_case.temperature}"
+        created_temperature = (created_case.model_settings or {}).get("temperature")
+        assert created_temperature == 0.3, f"Expected 0.3, got {created_temperature}"
         logger.info("✓ Temperature stored correctly in database")
         
         # Retrieve test case
         retrieved_case = service.get_test_case(created_case.id)
         assert retrieved_case is not None, "Test case not found"
-        assert retrieved_case.temperature == 0.3, f"Expected 0.3, got {retrieved_case.temperature}"
+        retrieved_temperature = (retrieved_case.model_settings or {}).get("temperature")
+        assert retrieved_temperature == 0.3, f"Expected 0.3, got {retrieved_temperature}"
         logger.info("✓ Temperature retrieved correctly from database")
         
         # Clean up

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -7,8 +7,4 @@ Main API package for replay-llm-call.
 from .factory import create_api, mount_api
 from .router import router
 
-__all__ = [
-    "router",
-    "create_api",
-    "mount_api"
-]
+__all__ = ["router", "create_api", "mount_api"]

--- a/src/api/pages.py
+++ b/src/api/pages.py
@@ -24,7 +24,11 @@ async def home_page(request: Request):
     """
     return templates.TemplateResponse(
         "test_cases.html",
-        {"request": request, "static_asset_version": settings.static__asset_version},
+        {
+            "request": request,
+            "static_asset_version": settings.static__asset_version,
+            "active_page": "test-cases",
+        },
     )
 
 
@@ -35,7 +39,11 @@ async def test_cases_page(request: Request):
     """
     return templates.TemplateResponse(
         "test_cases.html",
-        {"request": request, "static_asset_version": settings.static__asset_version},
+        {
+            "request": request,
+            "static_asset_version": settings.static__asset_version,
+            "active_page": "test-cases",
+        },
     )
 
 
@@ -46,7 +54,11 @@ async def test_execution_page(request: Request):
     """
     return templates.TemplateResponse(
         "test_execution.html",
-        {"request": request, "static_asset_version": settings.static__asset_version},
+        {
+            "request": request,
+            "static_asset_version": settings.static__asset_version,
+            "active_page": "test-execution",
+        },
     )
 
 
@@ -57,7 +69,11 @@ async def test_logs_page(request: Request):
     """
     return templates.TemplateResponse(
         "test_logs.html",
-        {"request": request, "static_asset_version": settings.static__asset_version},
+        {
+            "request": request,
+            "static_asset_version": settings.static__asset_version,
+            "active_page": "test-logs",
+        },
     )
 
 
@@ -67,7 +83,11 @@ async def agents_page(request: Request):
 
     return templates.TemplateResponse(
         "agents.html",
-        {"request": request, "static_asset_version": settings.static__asset_version},
+        {
+            "request": request,
+            "static_asset_version": settings.static__asset_version,
+            "active_page": "agents",
+        },
     )
 
 
@@ -77,7 +97,11 @@ async def regression_tests_page(request: Request):
 
     return templates.TemplateResponse(
         "regression_tests.html",
-        {"request": request, "static_asset_version": settings.static__asset_version},
+        {
+            "request": request,
+            "static_asset_version": settings.static__asset_version,
+            "active_page": "regression-tests",
+        },
     )
 
 
@@ -91,6 +115,7 @@ async def regression_test_detail_page(request: Request, regression_test_id: str)
             "request": request,
             "regression_test_id": regression_test_id,
             "static_asset_version": settings.static__asset_version,
+            "active_page": "regression-tests",
         },
     )
 
@@ -106,6 +131,7 @@ async def test_case_detail_page(request: Request, case_id: str):
             "request": request,
             "case_id": case_id,
             "static_asset_version": settings.static__asset_version,
+            "active_page": "test-cases",
         },
     )
 
@@ -121,6 +147,7 @@ async def test_log_detail_page(request: Request, log_id: str):
             "request": request,
             "log_id": log_id,
             "static_asset_version": settings.static__asset_version,
+            "active_page": "test-logs",
         },
     )
 

--- a/src/api/pages.py
+++ b/src/api/pages.py
@@ -72,7 +72,7 @@ async def test_case_detail_page(request: Request, case_id: str):
             "request": request,
             "case_id": case_id,
             "static_asset_version": settings.static__asset_version,
-        }
+        },
     )
 
 
@@ -87,7 +87,7 @@ async def test_log_detail_page(request: Request, log_id: str):
             "request": request,
             "log_id": log_id,
             "static_asset_version": settings.static__asset_version,
-        }
+        },
     )
 
 

--- a/src/api/pages.py
+++ b/src/api/pages.py
@@ -91,6 +91,21 @@ async def agents_page(request: Request):
     )
 
 
+@router.get("/agents/{agent_id}", response_class=HTMLResponse)
+async def agent_detail_page(request: Request, agent_id: str):
+    """Agent detail page."""
+
+    return templates.TemplateResponse(
+        "agent_detail.html",
+        {
+            "request": request,
+            "agent_id": agent_id,
+            "static_asset_version": settings.static__asset_version,
+            "active_page": "agents",
+        },
+    )
+
+
 @router.get("/regression-tests", response_class=HTMLResponse)
 async def regression_tests_page(request: Request):
     """Regression tests listing page."""

--- a/src/api/pages.py
+++ b/src/api/pages.py
@@ -61,6 +61,40 @@ async def test_logs_page(request: Request):
     )
 
 
+@router.get("/agents", response_class=HTMLResponse)
+async def agents_page(request: Request):
+    """Agent management page."""
+
+    return templates.TemplateResponse(
+        "agents.html",
+        {"request": request, "static_asset_version": settings.static__asset_version},
+    )
+
+
+@router.get("/regression-tests", response_class=HTMLResponse)
+async def regression_tests_page(request: Request):
+    """Regression tests listing page."""
+
+    return templates.TemplateResponse(
+        "regression_tests.html",
+        {"request": request, "static_asset_version": settings.static__asset_version},
+    )
+
+
+@router.get("/regression-tests/{regression_test_id}", response_class=HTMLResponse)
+async def regression_test_detail_page(request: Request, regression_test_id: str):
+    """Regression test detail page."""
+
+    return templates.TemplateResponse(
+        "regression_test_detail.html",
+        {
+            "request": request,
+            "regression_test_id": regression_test_id,
+            "static_asset_version": settings.static__asset_version,
+        },
+    )
+
+
 @router.get("/test-cases/{case_id}", response_class=HTMLResponse)
 async def test_case_detail_page(request: Request, case_id: str):
     """

--- a/src/api/v1/__init__.py
+++ b/src/api/v1/__init__.py
@@ -7,14 +7,18 @@ Version 1 of the replay-llm-call API endpoints.
 from fastapi import APIRouter
 
 from .endpoints import health_router
+from .endpoints.agents import router as agents_router
+from .endpoints.regression_tests import router as regression_tests_router
 from .endpoints.test_cases import router as test_cases_router
 from .endpoints.test_execution import router as test_execution_router
 from .endpoints.test_logs import router as test_logs_router
 
 router = APIRouter()
 router.include_router(health_router, tags=["health"])
+router.include_router(agents_router)
 router.include_router(test_cases_router)
 router.include_router(test_execution_router)
 router.include_router(test_logs_router)
+router.include_router(regression_tests_router)
 
 __all__ = ["router"]

--- a/src/api/v1/converters/__init__.py
+++ b/src/api/v1/converters/__init__.py
@@ -4,22 +4,38 @@ API Layer Converters
 Converters between API layer schemas and service layer schemas.
 """
 
+from .agent_converters import (
+    convert_agent_create_request,
+    convert_agent_data_to_response,
+    convert_agent_summary_to_response,
+    convert_agent_update_request,
+)
+from .regression_test_converters import (
+    convert_regression_test_create_request,
+    convert_regression_test_data_to_response,
+)
 from .test_case_converters import (
     convert_test_case_create_request,
+    convert_test_case_data_to_response,
     convert_test_case_update_request,
-    convert_test_case_data_to_response
 )
 from .test_execution_converters import (
     convert_test_execution_request,
-    convert_test_execution_result_to_response
+    convert_test_execution_result_to_response,
 )
 from .test_log_converters import convert_test_log_data_to_response
 
 __all__ = [
+    "convert_agent_create_request",
+    "convert_agent_update_request",
+    "convert_agent_data_to_response",
+    "convert_agent_summary_to_response",
+    "convert_regression_test_create_request",
+    "convert_regression_test_data_to_response",
     "convert_test_case_create_request",
-    "convert_test_case_update_request", 
+    "convert_test_case_update_request",
     "convert_test_case_data_to_response",
     "convert_test_execution_request",
     "convert_test_execution_result_to_response",
-    "convert_test_log_data_to_response"
+    "convert_test_log_data_to_response",
 ]

--- a/src/api/v1/converters/agent_converters.py
+++ b/src/api/v1/converters/agent_converters.py
@@ -34,7 +34,6 @@ def convert_agent_update_request(request: AgentUpdateRequest) -> AgentUpdateData
         default_model_name=request.default_model_name,
         default_system_prompt=request.default_system_prompt,
         default_model_settings=request.default_model_settings,
-        is_deleted=request.is_deleted,
     )
 
 

--- a/src/api/v1/converters/agent_converters.py
+++ b/src/api/v1/converters/agent_converters.py
@@ -1,0 +1,62 @@
+"""Agent API converters."""
+
+from src.api.v1.schemas.requests import AgentCreateRequest, AgentUpdateRequest
+from src.api.v1.schemas.responses.agent_responses import (
+    AgentResponse,
+    AgentSummaryResponse,
+)
+from src.services.agent_service import (
+    AgentCreateData,
+    AgentData,
+    AgentSummary,
+    AgentUpdateData,
+)
+
+
+def convert_agent_create_request(request: AgentCreateRequest) -> AgentCreateData:
+    """Convert API create request to service layer data."""
+
+    return AgentCreateData(
+        name=request.name,
+        description=request.description,
+        default_model_name=request.default_model_name,
+        default_system_prompt=request.default_system_prompt,
+        default_model_settings=request.default_model_settings,
+    )
+
+
+def convert_agent_update_request(request: AgentUpdateRequest) -> AgentUpdateData:
+    """Convert API update request to service layer data."""
+
+    return AgentUpdateData(
+        name=request.name,
+        description=request.description,
+        default_model_name=request.default_model_name,
+        default_system_prompt=request.default_system_prompt,
+        default_model_settings=request.default_model_settings,
+        is_deleted=request.is_deleted,
+    )
+
+
+def convert_agent_data_to_response(data: AgentData) -> AgentResponse:
+    """Convert service agent data to API response."""
+
+    return AgentResponse.model_validate(data)
+
+
+def convert_agent_summary_to_response(
+    summary: AgentSummary | None,
+) -> AgentSummaryResponse | None:
+    """Convert service summary to API summary response."""
+
+    if not summary:
+        return None
+    return AgentSummaryResponse.model_validate(summary)
+
+
+__all__ = [
+    "convert_agent_create_request",
+    "convert_agent_update_request",
+    "convert_agent_data_to_response",
+    "convert_agent_summary_to_response",
+]

--- a/src/api/v1/converters/regression_test_converters.py
+++ b/src/api/v1/converters/regression_test_converters.py
@@ -17,9 +17,9 @@ def convert_regression_test_create_request(
 
     return RegressionTestCreateData(
         agent_id=request.agent_id,
-        model_name=request.model_name,
-        system_prompt=request.system_prompt,
-        model_settings=request.model_settings,
+        model_name_override=request.model_name_override,
+        system_prompt_override=request.system_prompt_override,
+        model_settings_override=request.model_settings_override,
     )
 
 

--- a/src/api/v1/converters/regression_test_converters.py
+++ b/src/api/v1/converters/regression_test_converters.py
@@ -1,0 +1,53 @@
+"""Regression test API converters."""
+
+from src.api.v1.schemas.requests import RegressionTestCreateRequest
+from src.api.v1.schemas.responses import RegressionTestResponse
+from src.services.regression_test_service import (
+    RegressionTestCreateData,
+    RegressionTestData,
+)
+
+from .agent_converters import convert_agent_summary_to_response
+
+
+def convert_regression_test_create_request(
+    request: RegressionTestCreateRequest,
+) -> RegressionTestCreateData:
+    """Convert API create request to service layer data."""
+
+    return RegressionTestCreateData(
+        agent_id=request.agent_id,
+        model_name=request.model_name,
+        system_prompt=request.system_prompt,
+        model_settings=request.model_settings,
+    )
+
+
+def convert_regression_test_data_to_response(
+    data: RegressionTestData,
+) -> RegressionTestResponse:
+    """Convert service data to API response."""
+
+    return RegressionTestResponse(
+        id=data.id,
+        agent_id=data.agent_id,
+        status=data.status,
+        model_name_override=data.model_name_override,
+        system_prompt_override=data.system_prompt_override,
+        model_settings_override=data.model_settings_override,
+        total_count=data.total_count,
+        success_count=data.success_count,
+        failed_count=data.failed_count,
+        error_message=data.error_message,
+        started_at=data.started_at,
+        completed_at=data.completed_at,
+        created_at=data.created_at,
+        updated_at=data.updated_at,
+        agent=convert_agent_summary_to_response(data.agent),
+    )
+
+
+__all__ = [
+    "convert_regression_test_create_request",
+    "convert_regression_test_data_to_response",
+]

--- a/src/api/v1/converters/test_case_converters.py
+++ b/src/api/v1/converters/test_case_converters.py
@@ -5,27 +5,42 @@ Converters between API layer and service layer schemas for test cases.
 """
 
 from src.api.v1.schemas.requests import TestCaseCreateRequest, TestCaseUpdateRequest
-from src.api.v1.schemas.responses import TestCaseResponse
-from src.services.test_case_service import TestCaseCreateData, TestCaseUpdateData, TestCaseData
+from src.api.v1.schemas.responses.test_case_responses import (
+    AgentSummaryResponse as TestCaseAgentSummaryResponse,
+)
+from src.api.v1.schemas.responses.test_case_responses import (
+    TestCaseResponse,
+)
+from src.services.test_case_service import (
+    TestCaseCreateData,
+    TestCaseData,
+    TestCaseUpdateData,
+)
 
 
-def convert_test_case_create_request(request: TestCaseCreateRequest) -> TestCaseCreateData:
+def convert_test_case_create_request(
+    request: TestCaseCreateRequest,
+) -> TestCaseCreateData:
     """Convert API create request to service layer data."""
     return TestCaseCreateData(
         name=request.name,
         raw_data=request.raw_data,
-        description=request.description
+        description=request.description,
+        agent_id=request.agent_id,
     )
 
 
-def convert_test_case_update_request(request: TestCaseUpdateRequest) -> TestCaseUpdateData:
+def convert_test_case_update_request(
+    request: TestCaseUpdateRequest,
+) -> TestCaseUpdateData:
     """Convert API update request to service layer data."""
     return TestCaseUpdateData(
         name=request.name,
         raw_data=request.raw_data,
         description=request.description,
         system_prompt=request.system_prompt,
-        last_user_message=request.last_user_message
+        last_user_message=request.last_user_message,
+        agent_id=request.agent_id,
     )
 
 
@@ -42,7 +57,13 @@ def convert_test_case_data_to_response(data: TestCaseData) -> TestCaseResponse:
         model_settings=data.model_settings,
         system_prompt=data.system_prompt,
         last_user_message=data.last_user_message,
+        agent_id=data.agent_id,
+        agent=(
+            TestCaseAgentSummaryResponse.model_validate(data.agent)
+            if data.agent
+            else None
+        ),
         is_deleted=data.is_deleted,
         created_at=data.created_at,
-        updated_at=data.updated_at
+        updated_at=data.updated_at,
     )

--- a/src/api/v1/converters/test_execution_converters.py
+++ b/src/api/v1/converters/test_execution_converters.py
@@ -6,7 +6,7 @@ Converters between API layer and service layer schemas for test execution.
 
 from src.api.v1.schemas.requests import TestExecutionRequest
 from src.api.v1.schemas.responses import TestExecutionResponse
-from src.services.test_execution_service import TestExecutionData, TestExecutionResult
+from src.services.test_execution_service import TestExecutionData, ExecutionResult
 
 
 def convert_test_execution_request(request: TestExecutionRequest) -> TestExecutionData:
@@ -22,7 +22,7 @@ def convert_test_execution_request(request: TestExecutionRequest) -> TestExecuti
 
 
 def convert_test_execution_result_to_response(
-    result: TestExecutionResult,
+    result: ExecutionResult,
 ) -> TestExecutionResponse:
     """Convert service layer execution result to API response."""
     return TestExecutionResponse(

--- a/src/api/v1/converters/test_execution_converters.py
+++ b/src/api/v1/converters/test_execution_converters.py
@@ -6,7 +6,7 @@ Converters between API layer and service layer schemas for test execution.
 
 from src.api.v1.schemas.requests import TestExecutionRequest
 from src.api.v1.schemas.responses import TestExecutionResponse
-from src.services.test_execution_service import TestExecutionData, ExecutionResult
+from src.services.test_execution_service import ExecutionResult, TestExecutionData
 
 
 def convert_test_execution_request(request: TestExecutionRequest) -> TestExecutionData:

--- a/src/api/v1/converters/test_execution_converters.py
+++ b/src/api/v1/converters/test_execution_converters.py
@@ -17,20 +17,24 @@ def convert_test_execution_request(request: TestExecutionRequest) -> TestExecuti
         modified_system_prompt=request.modified_system_prompt,
         modified_last_user_message=request.modified_last_user_message,
         modified_tools=request.modified_tools,
-        modified_model_settings=request.modified_model_settings
+        modified_model_settings=request.modified_model_settings,
     )
 
 
-def convert_test_execution_result_to_response(result: TestExecutionResult) -> TestExecutionResponse:
+def convert_test_execution_result_to_response(
+    result: TestExecutionResult,
+) -> TestExecutionResponse:
     """Convert service layer execution result to API response."""
     return TestExecutionResponse(
         status=result.status,
         log_id=result.log_id,
+        agent_id=result.agent_id,
+        regression_test_id=result.regression_test_id,
         response_time_ms=result.response_time_ms,
         executed_at=result.executed_at,
         error_message=result.error_message,
         llm_response=result.llm_response,
         # Legacy fields for backward compatibility
         test_log=None,  # Can be populated if needed
-        error=result.error_message  # Legacy field mapping
+        error=result.error_message,  # Legacy field mapping
     )

--- a/src/api/v1/converters/test_log_converters.py
+++ b/src/api/v1/converters/test_log_converters.py
@@ -13,6 +13,8 @@ def convert_test_log_data_to_response(data: TestLogData) -> TestLogResponse:
     return TestLogResponse(
         id=data.id,
         test_case_id=data.test_case_id,
+        agent_id=data.agent_id,
+        regression_test_id=data.regression_test_id,
         model_name=data.model_name,
         model_settings=data.model_settings,
         system_prompt=data.system_prompt,
@@ -22,5 +24,5 @@ def convert_test_log_data_to_response(data: TestLogData) -> TestLogResponse:
         response_time_ms=data.response_time_ms,
         status=data.status,
         error_message=data.error_message,
-        created_at=data.created_at
+        created_at=data.created_at,
     )

--- a/src/api/v1/endpoints/__init__.py
+++ b/src/api/v1/endpoints/__init__.py
@@ -4,6 +4,12 @@ API Endpoints Package
 FastAPI endpoint definitions for replay-llm-call.
 """
 
+from .agents import router as agents_router
 from .health import router as health_router
+from .regression_tests import router as regression_tests_router
 
-__all__ = ["health_router"]
+__all__ = [
+    "health_router",
+    "agents_router",
+    "regression_tests_router",
+]

--- a/src/api/v1/endpoints/agents.py
+++ b/src/api/v1/endpoints/agents.py
@@ -59,6 +59,8 @@ async def update_agent(agent_id: str, request: AgentUpdateRequest) -> AgentRespo
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
         return convert_agent_data_to_response(agent)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except HTTPException:
         raise
     except Exception as exc:  # pragma: no cover - defensive logging

--- a/src/api/v1/endpoints/agents.py
+++ b/src/api/v1/endpoints/agents.py
@@ -1,0 +1,94 @@
+"""Agent management endpoints."""
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.api.v1.converters import (
+    convert_agent_create_request,
+    convert_agent_data_to_response,
+    convert_agent_update_request,
+)
+from src.api.v1.schemas.requests import AgentCreateRequest, AgentUpdateRequest
+from src.api.v1.schemas.responses import AgentResponse
+from src.core.logger import get_logger
+from src.services.agent_service import AgentService
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/agents", tags=["agents"])
+agent_service = AgentService()
+
+
+@router.post("/", response_model=AgentResponse)
+async def create_agent(request: AgentCreateRequest) -> AgentResponse:
+    try:
+        service_request = convert_agent_create_request(request)
+        agent = agent_service.create_agent(service_request)
+        return convert_agent_data_to_response(agent)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("API: Failed to create agent: %s", exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/", response_model=List[AgentResponse])
+async def list_agents(
+    include_deleted: bool = Query(False, description="Include soft-deleted agents"),
+) -> List[AgentResponse]:
+    try:
+        agents = agent_service.list_agents(include_deleted=include_deleted)
+        return [convert_agent_data_to_response(agent) for agent in agents]
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("API: Failed to list agents: %s", exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/{agent_id}", response_model=AgentResponse)
+async def get_agent(agent_id: str) -> AgentResponse:
+    agent = agent_service.get_agent(agent_id, include_deleted=True)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return convert_agent_data_to_response(agent)
+
+
+@router.put("/{agent_id}", response_model=AgentResponse)
+async def update_agent(agent_id: str, request: AgentUpdateRequest) -> AgentResponse:
+    try:
+        service_request = convert_agent_update_request(request)
+        agent = agent_service.update_agent(agent_id, service_request)
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        return convert_agent_data_to_response(agent)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("API: Failed to update agent %s: %s", agent_id, exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/{agent_id}")
+async def delete_agent(agent_id: str) -> dict:
+    try:
+        deleted = agent_service.delete_agent(agent_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        return {"message": "Agent deleted successfully"}
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("API: Failed to delete agent %s: %s", agent_id, exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/{agent_id}/restore", response_model=AgentResponse)
+async def restore_agent(agent_id: str) -> AgentResponse:
+    restored = agent_service.restore_agent(agent_id)
+    if not restored:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    agent = agent_service.get_agent(agent_id, include_deleted=True)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return convert_agent_data_to_response(agent)
+
+
+__all__ = ["router"]

--- a/src/api/v1/endpoints/regression_tests.py
+++ b/src/api/v1/endpoints/regression_tests.py
@@ -1,0 +1,86 @@
+"""Regression test endpoints."""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.api.v1.converters import (
+    convert_regression_test_create_request,
+    convert_regression_test_data_to_response,
+    convert_test_log_data_to_response,
+)
+from src.api.v1.schemas.requests import RegressionTestCreateRequest
+from src.api.v1.schemas.responses import RegressionTestResponse, TestLogResponse
+from src.core.logger import get_logger
+from src.services.regression_test_service import RegressionTestService
+from src.services.test_log_service import TestLogService
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/regression-tests", tags=["regression-tests"])
+regression_service = RegressionTestService()
+test_log_service = TestLogService()
+
+
+@router.post("/", response_model=RegressionTestResponse)
+async def start_regression(
+    request: RegressionTestCreateRequest,
+) -> RegressionTestResponse:
+    try:
+        service_request = convert_regression_test_create_request(request)
+        regression = await regression_service.run_regression_test(service_request)
+        return convert_regression_test_data_to_response(regression)
+    except ValueError as exc:
+        logger.error("API: Invalid regression request: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("API: Failed to start regression: %s", exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/", response_model=List[RegressionTestResponse])
+async def list_regressions(
+    agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
+    status: Optional[str] = Query(None, description="Filter by status"),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> List[RegressionTestResponse]:
+    try:
+        records = regression_service.list_regression_tests(
+            agent_id=agent_id, status=status, limit=limit, offset=offset
+        )
+        return [convert_regression_test_data_to_response(record) for record in records]
+    except Exception as exc:  # pragma: no cover
+        logger.error("API: Failed to list regressions: %s", exc)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/{regression_test_id}", response_model=RegressionTestResponse)
+async def get_regression(regression_test_id: str) -> RegressionTestResponse:
+    record = regression_service.get_regression_test(regression_test_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="Regression test not found")
+    return convert_regression_test_data_to_response(record)
+
+
+@router.get("/{regression_test_id}/logs", response_model=List[TestLogResponse])
+async def get_regression_logs(
+    regression_test_id: str,
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+) -> List[TestLogResponse]:
+    try:
+        logs = test_log_service.get_logs_by_regression_test(
+            regression_test_id, limit=limit, offset=offset
+        )
+        return [convert_test_log_data_to_response(log) for log in logs]
+    except Exception as exc:  # pragma: no cover
+        logger.error(
+            "API: Failed to fetch regression logs for %s: %s",
+            regression_test_id,
+            exc,
+        )
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+__all__ = ["router"]

--- a/src/api/v1/endpoints/test_execution.py
+++ b/src/api/v1/endpoints/test_execution.py
@@ -8,13 +8,13 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 
-from src.core.logger import get_logger
-from src.api.v1.schemas.requests import TestExecutionRequest
-from src.api.v1.schemas.responses import TestExecutionResponse
 from src.api.v1.converters import (
     convert_test_execution_request,
-    convert_test_execution_result_to_response
+    convert_test_execution_result_to_response,
 )
+from src.api.v1.schemas.requests import TestExecutionRequest
+from src.api.v1.schemas.responses import TestExecutionResponse
+from src.core.logger import get_logger
 from src.services.test_execution_service import TestExecutionService
 
 logger = get_logger(__name__)
@@ -27,13 +27,13 @@ test_execution_service = TestExecutionService()
 async def execute_test(request: TestExecutionRequest):
     """
     Execute a test case synchronously.
-    
+
     Args:
         request: Test execution request
-        
+
     Returns:
         TestExecutionResponse: Execution results
-        
+
     Raises:
         HTTPException: If execution fails or test case not found
     """
@@ -59,34 +59,34 @@ async def execute_test_by_id(
     test_case_id: str,
     model_name: Optional[str] = None,
     system_prompt: Optional[str] = None,
-    user_message: Optional[str] = None
+    user_message: Optional[str] = None,
 ):
     """
     Execute a test case by ID with optional parameter overrides.
-    
+
     Args:
         test_case_id: Test case ID to execute
         model_name: Optional model name override
         system_prompt: Optional system prompt override
         user_message: Optional user message override
-        
+
     Returns:
         TestExecutionResponse: Execution results
-        
+
     Raises:
         HTTPException: If execution fails or test case not found
     """
     try:
         logger.info(f"API: Executing test case by ID: {test_case_id}")
-        
+
         # Create execution request from parameters
         request = TestExecutionRequest(
             test_case_id=test_case_id,
             model_name=model_name,
             system_prompt=system_prompt,
-            user_message=user_message
+            user_message=user_message,
         )
-        
+
         # Convert API request to service layer data
         service_data = convert_test_execution_request(request)
         result = await test_execution_service.execute_test(service_data)

--- a/src/api/v1/schemas/__init__.py
+++ b/src/api/v1/schemas/__init__.py
@@ -5,7 +5,12 @@ Pydantic models for demo API request and response data.
 """
 
 from .requests import TestCaseCreateRequest, TestCaseUpdateRequest, TestExecutionRequest
-from .responses import TestCaseResponse, TestExecutionResponse, TestLogResponse, HealthResponse
+from .responses import (
+    HealthResponse,
+    TestCaseResponse,
+    TestExecutionResponse,
+    TestLogResponse,
+)
 
 __all__ = [
     "TestCaseCreateRequest",
@@ -14,5 +19,5 @@ __all__ = [
     "TestCaseResponse",
     "TestExecutionResponse",
     "TestLogResponse",
-    "HealthResponse"
+    "HealthResponse",
 ]

--- a/src/api/v1/schemas/requests/__init__.py
+++ b/src/api/v1/schemas/requests/__init__.py
@@ -4,11 +4,16 @@ V1 API Request Schemas
 Request schemas for all API v1 endpoints.
 """
 
+from .agent_requests import AgentCreateRequest, AgentUpdateRequest
+from .regression_test_requests import RegressionTestCreateRequest
 from .test_case_requests import TestCaseCreateRequest, TestCaseUpdateRequest
 from .test_execution_requests import TestExecutionRequest
 
 __all__ = [
+    "AgentCreateRequest",
+    "AgentUpdateRequest",
     "TestCaseCreateRequest",
     "TestCaseUpdateRequest",
-    "TestExecutionRequest"
+    "TestExecutionRequest",
+    "RegressionTestCreateRequest",
 ]

--- a/src/api/v1/schemas/requests/agent_requests.py
+++ b/src/api/v1/schemas/requests/agent_requests.py
@@ -31,9 +31,6 @@ class AgentUpdateRequest(BaseModel):
     default_model_name: Optional[str] = Field(None)
     default_system_prompt: Optional[str] = Field(None)
     default_model_settings: Optional[dict] = Field(None)
-    is_deleted: Optional[bool] = Field(
-        None, description="Soft delete flag (administrative use)"
-    )
 
 
 __all__ = ["AgentCreateRequest", "AgentUpdateRequest"]

--- a/src/api/v1/schemas/requests/agent_requests.py
+++ b/src/api/v1/schemas/requests/agent_requests.py
@@ -1,0 +1,39 @@
+"""Agent API request schemas."""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AgentCreateRequest(BaseModel):
+    """Request body for creating an agent."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Agent name")
+    description: Optional[str] = Field(
+        None, max_length=2000, description="Agent description"
+    )
+    default_model_name: Optional[str] = Field(
+        None, description="Default model name for regression runs"
+    )
+    default_system_prompt: Optional[str] = Field(
+        None, description="Default system prompt for regression runs"
+    )
+    default_model_settings: Optional[dict] = Field(
+        None, description="Default model settings JSON"
+    )
+
+
+class AgentUpdateRequest(BaseModel):
+    """Request body for updating an agent."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=2000)
+    default_model_name: Optional[str] = Field(None)
+    default_system_prompt: Optional[str] = Field(None)
+    default_model_settings: Optional[dict] = Field(None)
+    is_deleted: Optional[bool] = Field(
+        None, description="Soft delete flag (administrative use)"
+    )
+
+
+__all__ = ["AgentCreateRequest", "AgentUpdateRequest"]

--- a/src/api/v1/schemas/requests/regression_test_requests.py
+++ b/src/api/v1/schemas/requests/regression_test_requests.py
@@ -1,0 +1,19 @@
+"""Regression test API request schemas."""
+
+from typing import Dict
+
+from pydantic import BaseModel, Field
+
+
+class RegressionTestCreateRequest(BaseModel):
+    """Request body to start a regression test."""
+
+    agent_id: str = Field(..., description="Agent identifier")
+    model_name: str = Field(..., description="Model name override")
+    system_prompt: str = Field(..., description="System prompt override")
+    model_settings: Dict = Field(
+        default_factory=dict, description="Model settings override JSON"
+    )
+
+
+__all__ = ["RegressionTestCreateRequest"]

--- a/src/api/v1/schemas/requests/regression_test_requests.py
+++ b/src/api/v1/schemas/requests/regression_test_requests.py
@@ -9,9 +9,9 @@ class RegressionTestCreateRequest(BaseModel):
     """Request body to start a regression test."""
 
     agent_id: str = Field(..., description="Agent identifier")
-    model_name: str = Field(..., description="Model name override")
-    system_prompt: str = Field(..., description="System prompt override")
-    model_settings: Dict = Field(
+    model_name_override: str = Field(..., description="Model name override")
+    system_prompt_override: str = Field(..., description="System prompt override")
+    model_settings_override: Dict = Field(
         default_factory=dict, description="Model settings override JSON"
     )
 

--- a/src/api/v1/schemas/requests/test_case_requests.py
+++ b/src/api/v1/schemas/requests/test_case_requests.py
@@ -17,9 +17,7 @@ class TestCaseCreateRequest(BaseModel):
     description: Optional[str] = Field(
         None, max_length=1000, description="Test case description"
     )
-    agent_id: str = Field(
-        ..., description="Agent that owns the new test case"
-    )
+    agent_id: str = Field(..., description="Agent that owns the new test case")
 
 
 class TestCaseUpdateRequest(BaseModel):

--- a/src/api/v1/schemas/requests/test_case_requests.py
+++ b/src/api/v1/schemas/requests/test_case_requests.py
@@ -17,8 +17,8 @@ class TestCaseCreateRequest(BaseModel):
     description: Optional[str] = Field(
         None, max_length=1000, description="Test case description"
     )
-    agent_id: Optional[str] = Field(
-        None, description="Agent that owns the new test case"
+    agent_id: str = Field(
+        ..., description="Agent that owns the new test case"
     )
 
 

--- a/src/api/v1/schemas/requests/test_case_requests.py
+++ b/src/api/v1/schemas/requests/test_case_requests.py
@@ -11,17 +11,27 @@ from pydantic import BaseModel, Field
 
 class TestCaseCreateRequest(BaseModel):
     """Request model for creating a new test case."""
-    
+
     name: str = Field(..., min_length=1, max_length=255, description="Test case name")
     raw_data: Dict = Field(..., description="Raw logfire data")
-    description: Optional[str] = Field(None, max_length=1000, description="Test case description")
+    description: Optional[str] = Field(
+        None, max_length=1000, description="Test case description"
+    )
+    agent_id: Optional[str] = Field(
+        None, description="Agent that owns the new test case"
+    )
 
 
 class TestCaseUpdateRequest(BaseModel):
     """Request model for updating a test case."""
 
-    name: Optional[str] = Field(None, min_length=1, max_length=255, description="Updated test case name")
+    name: Optional[str] = Field(
+        None, min_length=1, max_length=255, description="Updated test case name"
+    )
     raw_data: Optional[Dict] = Field(None, description="Updated raw logfire data")
-    description: Optional[str] = Field(None, max_length=1000, description="Updated test case description")
+    description: Optional[str] = Field(
+        None, max_length=1000, description="Updated test case description"
+    )
     system_prompt: Optional[str] = Field(None, description="Updated system prompt")
     last_user_message: Optional[str] = Field(None, description="Updated user message")
+    agent_id: Optional[str] = Field(None, description="Updated owning agent")

--- a/src/api/v1/schemas/requests/test_execution_requests.py
+++ b/src/api/v1/schemas/requests/test_execution_requests.py
@@ -15,7 +15,15 @@ class TestExecutionRequest(BaseModel):
     test_case_id: str = Field(..., description="ID of the test case to execute")
     # User may modify these parameters (if None, use original values)
     modified_model_name: Optional[str] = Field(None, description="Override model name")
-    modified_system_prompt: Optional[str] = Field(None, description="Override system prompt")
-    modified_last_user_message: Optional[str] = Field(None, description="Override user message")
-    modified_tools: Optional[List[Dict]] = Field(None, description="Override tools configuration")
-    modified_model_settings: Optional[Dict] = Field(None, description="Override model settings JSON")
+    modified_system_prompt: Optional[str] = Field(
+        None, description="Override system prompt"
+    )
+    modified_last_user_message: Optional[str] = Field(
+        None, description="Override user message"
+    )
+    modified_tools: Optional[List[Dict]] = Field(
+        None, description="Override tools configuration"
+    )
+    modified_model_settings: Optional[Dict] = Field(
+        None, description="Override model settings JSON"
+    )

--- a/src/api/v1/schemas/responses/__init__.py
+++ b/src/api/v1/schemas/responses/__init__.py
@@ -4,14 +4,19 @@ V1 API Response Schemas
 Response schemas for all API v1 endpoints.
 """
 
+from .agent_responses import AgentResponse, AgentSummaryResponse
 from .health_response import HealthResponse
+from .regression_test_responses import RegressionTestResponse
 from .test_case_responses import TestCaseResponse
 from .test_execution_responses import TestExecutionResponse
 from .test_log_responses import TestLogResponse
 
 __all__ = [
+    "AgentResponse",
+    "AgentSummaryResponse",
     "HealthResponse",
+    "RegressionTestResponse",
     "TestCaseResponse",
     "TestExecutionResponse",
-    "TestLogResponse"
+    "TestLogResponse",
 ]

--- a/src/api/v1/schemas/responses/agent_responses.py
+++ b/src/api/v1/schemas/responses/agent_responses.py
@@ -1,0 +1,43 @@
+"""Agent API response schemas."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AgentResponse(BaseModel):
+    """Full agent response."""
+
+    id: str = Field(..., description="Agent identifier")
+    name: str = Field(..., description="Agent name")
+    description: Optional[str] = Field(None, description="Agent description")
+    default_model_name: Optional[str] = Field(
+        None, description="Default model name for regression runs"
+    )
+    default_system_prompt: Optional[str] = Field(
+        None, description="Default system prompt"
+    )
+    default_model_settings: Optional[dict] = Field(
+        None, description="Default model settings JSON"
+    )
+    is_deleted: bool = Field(False, description="Soft delete flag")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    class Config:
+        from_attributes = True
+
+
+class AgentSummaryResponse(BaseModel):
+    """Short agent representation for embedding."""
+
+    id: str = Field(..., description="Agent identifier")
+    name: str = Field(..., description="Agent name")
+    description: Optional[str] = Field(None, description="Agent description")
+
+    class Config:
+        from_attributes = True
+
+
+__all__ = ["AgentResponse", "AgentSummaryResponse"]

--- a/src/api/v1/schemas/responses/agent_responses.py
+++ b/src/api/v1/schemas/responses/agent_responses.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AgentResponse(BaseModel):
@@ -25,8 +25,7 @@ class AgentResponse(BaseModel):
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AgentSummaryResponse(BaseModel):
@@ -36,8 +35,7 @@ class AgentSummaryResponse(BaseModel):
     name: str = Field(..., description="Agent name")
     description: Optional[str] = Field(None, description="Agent description")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 __all__ = ["AgentResponse", "AgentSummaryResponse"]

--- a/src/api/v1/schemas/responses/health_response.py
+++ b/src/api/v1/schemas/responses/health_response.py
@@ -6,7 +6,7 @@ Response models for API health check endpoints.
 
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class HealthResponse(BaseModel):
@@ -22,8 +22,8 @@ class HealthResponse(BaseModel):
         ..., description="Health status of individual components"
     )
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": "healthy",
                 "timestamp": "2024-01-15T10:30:00.000Z",
@@ -46,3 +46,4 @@ class HealthResponse(BaseModel):
                 },
             }
         }
+    )

--- a/src/api/v1/schemas/responses/regression_test_responses.py
+++ b/src/api/v1/schemas/responses/regression_test_responses.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from .agent_responses import AgentSummaryResponse
 
@@ -31,8 +31,7 @@ class RegressionTestResponse(BaseModel):
         None, description="Summary information about the agent"
     )
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 __all__ = ["RegressionTestResponse"]

--- a/src/api/v1/schemas/responses/regression_test_responses.py
+++ b/src/api/v1/schemas/responses/regression_test_responses.py
@@ -1,0 +1,38 @@
+"""Regression test API response schemas."""
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+from .agent_responses import AgentSummaryResponse
+
+
+class RegressionTestResponse(BaseModel):
+    """Response model representing a regression test run."""
+
+    id: str = Field(..., description="Regression test identifier")
+    agent_id: str = Field(..., description="Agent identifier")
+    status: str = Field(..., description="Regression status")
+    model_name_override: str = Field(..., description="Model name override")
+    system_prompt_override: str = Field(..., description="System prompt override")
+    model_settings_override: Dict = Field(..., description="Model settings override")
+    total_count: int = Field(..., description="Total number of executed test cases")
+    success_count: int = Field(..., description="Number of successful executions")
+    failed_count: int = Field(..., description="Number of failed executions")
+    error_message: Optional[str] = Field(
+        None, description="Aggregated error message if the regression failed"
+    )
+    started_at: Optional[datetime] = Field(None, description="Start timestamp")
+    completed_at: Optional[datetime] = Field(None, description="Completion timestamp")
+    created_at: datetime = Field(..., description="Record creation timestamp")
+    updated_at: datetime = Field(..., description="Record update timestamp")
+    agent: Optional[AgentSummaryResponse] = Field(
+        None, description="Summary information about the agent"
+    )
+
+    class Config:
+        from_attributes = True
+
+
+__all__ = ["RegressionTestResponse"]

--- a/src/api/v1/schemas/responses/test_case_responses.py
+++ b/src/api/v1/schemas/responses/test_case_responses.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from .agent_responses import AgentSummaryResponse
+
 
 class TestCaseResponse(BaseModel):
     """Response model for test case data."""
@@ -20,12 +22,20 @@ class TestCaseResponse(BaseModel):
     middle_messages: List[Dict] = Field(..., description="Middle messages for replay")
     tools: Optional[List[Dict]] = Field(None, description="Tools configuration")
     model_name: str = Field(..., description="Model name")
-    model_settings: Optional[Dict] = Field(None, description="Model settings JSON (temperature, max_tokens, etc.)")
+    model_settings: Optional[Dict] = Field(
+        None, description="Model settings JSON (temperature, max_tokens, etc.)"
+    )
     system_prompt: str = Field(..., description="System prompt")
     last_user_message: str = Field(..., description="Last user message")
-    is_deleted: bool = Field(False, description="Indicates whether the test case is soft deleted")
+    agent_id: str = Field(..., description="Owning agent ID")
+    agent: Optional[AgentSummaryResponse] = Field(
+        None, description="Owning agent summary"
+    )
+    is_deleted: bool = Field(
+        False, description="Indicates whether the test case is soft deleted"
+    )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
-    
+
     class Config:
         from_attributes = True

--- a/src/api/v1/schemas/responses/test_case_responses.py
+++ b/src/api/v1/schemas/responses/test_case_responses.py
@@ -7,7 +7,7 @@ API response models for test case endpoints.
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from .agent_responses import AgentSummaryResponse
 
@@ -37,5 +37,4 @@ class TestCaseResponse(BaseModel):
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/src/api/v1/schemas/responses/test_execution_responses.py
+++ b/src/api/v1/schemas/responses/test_execution_responses.py
@@ -14,12 +14,22 @@ class TestExecutionResponse(BaseModel):
     """Response model for test execution results."""
 
     status: str = Field(..., description="Execution status (success/failed)")
-    log_id: Optional[str] = Field(None, description="Test log ID if execution completed")
-    response_time_ms: Optional[int] = Field(None, description="Response time in milliseconds")
+    log_id: Optional[str] = Field(
+        None, description="Test log ID if execution completed"
+    )
+    agent_id: Optional[str] = Field(None, description="Agent used for execution")
+    regression_test_id: Optional[str] = Field(
+        None, description="Regression test context for the execution"
+    )
+    response_time_ms: Optional[int] = Field(
+        None, description="Response time in milliseconds"
+    )
     executed_at: Optional[datetime] = Field(None, description="Execution timestamp")
-    error_message: Optional[str] = Field(None, description="Error message if execution failed")
+    error_message: Optional[str] = Field(
+        None, description="Error message if execution failed"
+    )
     llm_response: Optional[str] = Field(None, description="LLM response text")
-    
+
     # Legacy fields for backward compatibility
     test_log: Optional[dict] = Field(None, description="Legacy test log data")
     error: Optional[str] = Field(None, description="Legacy error field")

--- a/src/api/v1/schemas/responses/test_log_responses.py
+++ b/src/api/v1/schemas/responses/test_log_responses.py
@@ -15,16 +15,24 @@ class TestLogResponse(BaseModel):
 
     id: str = Field(..., description="Test log ID")
     test_case_id: str = Field(..., description="Associated test case ID")
+    agent_id: str = Field(..., description="Associated agent ID")
+    regression_test_id: Optional[str] = Field(
+        None, description="Regression test identifier if applicable"
+    )
     model_name: str = Field(..., description="Model used for execution")
-    model_settings: Optional[Dict] = Field(None, description="Model settings JSON used for execution")
+    model_settings: Optional[Dict] = Field(
+        None, description="Model settings JSON used for execution"
+    )
     system_prompt: str = Field(..., description="System prompt used")
     user_message: str = Field(..., description="User message used")
     tools: Optional[List[Dict]] = Field(None, description="Tools configuration used")
     llm_response: Optional[str] = Field(None, description="LLM response text")
-    response_time_ms: Optional[int] = Field(None, description="Response time in milliseconds")
+    response_time_ms: Optional[int] = Field(
+        None, description="Response time in milliseconds"
+    )
     status: str = Field(..., description="Execution status")
     error_message: Optional[str] = Field(None, description="Error message if failed")
     created_at: datetime = Field(..., description="Creation timestamp")
-    
+
     class Config:
         from_attributes = True

--- a/src/api/v1/schemas/responses/test_log_responses.py
+++ b/src/api/v1/schemas/responses/test_log_responses.py
@@ -7,7 +7,7 @@ API response models for test log endpoints.
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TestLogResponse(BaseModel):
@@ -34,5 +34,4 @@ class TestLogResponse(BaseModel):
     error_message: Optional[str] = Field(None, description="Error message if failed")
     created_at: datetime = Field(..., description="Creation timestamp")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -9,7 +9,7 @@ from typing import List, Literal, Optional
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-STATIC_ASSET_VERSION = "202509210030"
+STATIC_ASSET_VERSION = "202509210135"
 
 
 class Settings(BaseSettings):

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -9,7 +9,7 @@ from typing import List, Literal, Optional
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-STATIC_ASSET_VERSION = "202509202133"
+STATIC_ASSET_VERSION = "202509210030"
 
 
 class Settings(BaseSettings):

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -9,7 +9,6 @@ from typing import List, Literal, Optional
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-
 STATIC_ASSET_VERSION = "202509202133"
 
 

--- a/src/core/logger.py
+++ b/src/core/logger.py
@@ -55,8 +55,6 @@ def _sanitize_attributes(attrs: Dict[str, Any]) -> Dict[str, Any]:
 _session_id_context: ContextVar[Optional[str]] = ContextVar("session_id", default=None)
 
 
-
-
 def set_session_id(session_id: str) -> None:
     """Set the session ID in the current context for logging."""
     _session_id_context.set(session_id)
@@ -342,7 +340,6 @@ def setup_logfire_handler() -> None:
     except (AttributeError, TypeError, ValueError) as e:
         # Use print instead of logger since logging might not be fully configured
         print(f"⚠️  Failed to configure Logfire handler: {e}")
-
 
 
 @lru_cache(maxsize=1)

--- a/src/core/logger.py
+++ b/src/core/logger.py
@@ -198,9 +198,12 @@ class SessionAwareLogfireHandler(logging.Handler):
                 msg = str(record.msg)
 
             # Send to logfire
+            # For messages coming from standard logging, we have already formatted messages
+            # We need to escape braces to prevent Logfire from treating them as placeholders
+            escaped_msg = msg.replace("{", "{{").replace("}", "}}")
             logfire_with_session.log(
                 level=record.levelname.lower(),
-                msg_template=msg,
+                msg_template=escaped_msg,
                 attributes=attributes,
                 exc_info=record.exc_info,
             )

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -5,7 +5,9 @@ Data models and schemas for replay-llm-call.
 Contains SQLAlchemy models for database entities and Pydantic schemas for API validation.
 """
 
+from .agent import Agent
 from .base import Base, BaseDBModel, TimestampMixin
+from .regression_test import RegressionTest
 from .test_case import TestCase
 from .test_log import TestLog
 
@@ -15,6 +17,8 @@ __all__ = [
     "BaseDBModel",
     "TimestampMixin",
     # Database models
+    "Agent",
     "TestCase",
     "TestLog",
+    "RegressionTest",
 ]

--- a/src/models/agent.py
+++ b/src/models/agent.py
@@ -1,11 +1,18 @@
 """Agent SQLAlchemy model."""
 
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import JSON, Boolean, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import BaseDBModel
+
+if TYPE_CHECKING:  # pragma: no cover - imports only needed for type checking
+    from .regression_test import RegressionTest
+    from .test_case import TestCase
+    from .test_log import TestLog
 
 
 class Agent(BaseDBModel):

--- a/src/models/agent.py
+++ b/src/models/agent.py
@@ -1,0 +1,43 @@
+"""Agent SQLAlchemy model."""
+
+from typing import List, Optional
+
+from sqlalchemy import JSON, Boolean, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import BaseDBModel
+
+
+class Agent(BaseDBModel):
+    """Represents a logical LLM agent that groups test cases."""
+
+    __tablename__ = "agents"
+
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    default_model_name: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )
+    default_system_prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    default_model_settings: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    test_cases: Mapped[List["TestCase"]] = relationship(
+        "TestCase",
+        back_populates="agent",
+    )
+    regression_tests: Mapped[List["RegressionTest"]] = relationship(
+        "RegressionTest",
+        back_populates="agent",
+    )
+    test_logs: Mapped[List["TestLog"]] = relationship(
+        "TestLog",
+        back_populates="agent",
+    )
+
+    def __repr__(self) -> str:
+        status = "deleted" if self.is_deleted else "active"
+        return f"<Agent(id='{self.id}', name='{self.name}', status='{status}')>"
+
+
+__all__ = ["Agent"]

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -16,15 +16,13 @@ class TimestampMixin:
     """Mixin for models that need created_at and updated_at timestamps."""
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime,
-        default=lambda: datetime.now(timezone.utc),
-        nullable=False
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
-        nullable=False
+        nullable=False,
     )
 
 

--- a/src/models/regression_test.py
+++ b/src/models/regression_test.py
@@ -1,0 +1,51 @@
+"""Regression test SQLAlchemy model."""
+
+from typing import List, Optional
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import BaseDBModel
+
+
+class RegressionTest(BaseDBModel):
+    """Represents a batched regression execution for a single agent."""
+
+    __tablename__ = "regression_tests"
+
+    agent_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("agents.id"),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(String(32), default="pending", nullable=False)
+    model_name_override: Mapped[str] = mapped_column(String(255), nullable=False)
+    system_prompt_override: Mapped[str] = mapped_column(Text, nullable=False)
+    model_settings_override: Mapped[dict] = mapped_column(
+        JSON, nullable=False, default=dict
+    )
+
+    total_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    success_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    failed_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    started_at: Mapped[Optional[DateTime]] = mapped_column(DateTime, nullable=True)
+    completed_at: Mapped[Optional[DateTime]] = mapped_column(DateTime, nullable=True)
+
+    agent: Mapped["Agent"] = relationship(
+        "Agent",
+        back_populates="regression_tests",
+    )
+    test_logs: Mapped[List["TestLog"]] = relationship(
+        "TestLog",
+        back_populates="regression_test",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<RegressionTest(id='{self.id}', agent_id='{self.agent_id}', "
+            f"status='{self.status}', total={self.total_count})>"
+        )
+
+
+__all__ = ["RegressionTest"]

--- a/src/models/regression_test.py
+++ b/src/models/regression_test.py
@@ -1,11 +1,17 @@
 """Regression test SQLAlchemy model."""
 
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import BaseDBModel
+
+if TYPE_CHECKING:  # pragma: no cover - imports only needed for type checking
+    from .agent import Agent
+    from .test_log import TestLog
 
 
 class RegressionTest(BaseDBModel):

--- a/src/models/regression_test.py
+++ b/src/models/regression_test.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import BaseDBModel
@@ -24,6 +24,7 @@ class RegressionTest(BaseDBModel):
     model_settings_override: Mapped[dict] = mapped_column(
         JSON, nullable=False, default=dict
     )
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
     total_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     success_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)

--- a/src/models/test_case.py
+++ b/src/models/test_case.py
@@ -1,11 +1,17 @@
 """Test Case SQLAlchemy model."""
 
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import JSON, Boolean, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import BaseDBModel
+
+if TYPE_CHECKING:  # pragma: no cover - imports only needed for type checking
+    from .agent import Agent
+    from .test_log import TestLog
 
 
 class TestCase(BaseDBModel):

--- a/src/models/test_case.py
+++ b/src/models/test_case.py
@@ -1,35 +1,32 @@
-"""
-Test Case Model
-
-Data model for LLM test cases in the replay system.
-"""
+"""Test Case SQLAlchemy model."""
 
 from typing import List, Optional
 
-from sqlalchemy import Boolean, JSON, String, Text
+from sqlalchemy import JSON, Boolean, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import BaseDBModel
 
 
 class TestCase(BaseDBModel):
-    """
-    Test case model for storing LLM test scenarios.
-    
-    Stores both raw logfire data and parsed components for efficient replay.
-    Uses the optimized storage strategy where system prompt and last user message
-    are separated from other messages for efficient replay reconstruction.
-    """
-    
+    """Test case model for storing LLM test scenarios."""
+
     __tablename__ = "test_cases"
-    
+
+    # Agent relationship
+    agent_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("agents.id"),
+        nullable=False,
+    )
+
     # Basic information
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    
+
     # Raw data storage (for audit and reference)
     raw_data: Mapped[dict] = mapped_column(JSON, nullable=False)
-    
+
     # Separated storage for efficient replay
     # middle_messages contains all messages EXCEPT the first system prompt
     # and the last user message (which are stored separately below)
@@ -46,18 +43,22 @@ class TestCase(BaseDBModel):
     is_deleted: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
-        default=False
+        default=False,
     )
-    
+
     # Relationships
-    test_logs: Mapped[List["TestLog"]] = relationship(
-        "TestLog", 
-        back_populates="test_case",
-        cascade="all, delete-orphan"
+    agent: Mapped["Agent"] = relationship(
+        "Agent",
+        back_populates="test_cases",
     )
-    
+    test_logs: Mapped[List["TestLog"]] = relationship(
+        "TestLog",
+        back_populates="test_case",
+        cascade="all, delete-orphan",
+    )
+
     def __repr__(self) -> str:
-        return f"<TestCase(id='{self.id}', name='{self.name}')>"
+        return f"<TestCase(id='{self.id}', name='{self.name}', agent_id='{self.agent_id}')>"
 
 
 __all__ = ["TestCase"]

--- a/src/models/test_log.py
+++ b/src/models/test_log.py
@@ -1,11 +1,18 @@
 """Test Log SQLAlchemy model."""
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import JSON, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import BaseDBModel
+
+if TYPE_CHECKING:  # pragma: no cover - imports only needed for type checking
+    from .agent import Agent
+    from .regression_test import RegressionTest
+    from .test_case import TestCase
 
 
 class TestLog(BaseDBModel):

--- a/src/services/agent_service.py
+++ b/src/services/agent_service.py
@@ -154,10 +154,15 @@ class AgentService:
             agent.default_system_prompt = data.default_system_prompt
         if data.default_model_settings is not None:
             agent.default_model_settings = data.default_model_settings
+        original_is_deleted = agent.is_deleted
+
         if data.is_deleted is not None:
             agent.is_deleted = data.is_deleted
 
         updated = self.store.update(agent)
+
+        if data.is_deleted is True and original_is_deleted is False:
+            self.test_case_store.soft_delete_by_agent(agent_id)
         return AgentData.model_validate(updated)
 
     def delete_agent(self, agent_id: str) -> bool:

--- a/src/services/agent_service.py
+++ b/src/services/agent_service.py
@@ -1,0 +1,197 @@
+"""Business logic for managing agents."""
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from src.core.logger import get_logger
+from src.models import Agent
+from src.stores.agent_store import AgentStore
+from src.stores.test_case_store import TestCaseStore
+
+logger = get_logger(__name__)
+
+
+class AgentSummary(BaseModel):
+    """Light-weight agent projection for embedding in other responses."""
+
+    id: str = Field(..., description="Agent identifier")
+    name: str = Field(..., description="Agent name")
+    description: Optional[str] = Field(None, description="Agent description")
+
+    class Config:
+        from_attributes = True
+
+
+class AgentCreateData(BaseModel):
+    """Input payload for creating an agent."""
+
+    name: str = Field(..., description="Agent name")
+    description: Optional[str] = Field(None, description="Agent description")
+    default_model_name: Optional[str] = Field(
+        None, description="Default model name applied during regression"
+    )
+    default_system_prompt: Optional[str] = Field(
+        None, description="Default system prompt applied during regression"
+    )
+    default_model_settings: Optional[dict] = Field(
+        None, description="Default model settings JSON"
+    )
+
+
+class AgentUpdateData(BaseModel):
+    """Input payload for updating an agent."""
+
+    name: Optional[str] = Field(None, description="Agent name")
+    description: Optional[str] = Field(None, description="Agent description")
+    default_model_name: Optional[str] = Field(None, description="Default model name")
+    default_system_prompt: Optional[str] = Field(
+        None, description="Default system prompt"
+    )
+    default_model_settings: Optional[dict] = Field(
+        None, description="Default model settings JSON"
+    )
+    is_deleted: Optional[bool] = Field(
+        None, description="Soft delete flag (service use only)"
+    )
+
+
+class AgentData(BaseModel):
+    """Full agent representation."""
+
+    id: str = Field(..., description="Agent identifier")
+    name: str = Field(..., description="Agent name")
+    description: Optional[str] = Field(None, description="Agent description")
+    default_model_name: Optional[str] = Field(
+        None, description="Default model name applied during regression"
+    )
+    default_system_prompt: Optional[str] = Field(
+        None, description="Default system prompt applied during regression"
+    )
+    default_model_settings: Optional[dict] = Field(
+        None, description="Default model settings JSON"
+    )
+    is_deleted: bool = Field(False, description="Soft delete flag")
+    created_at: Optional[datetime] = Field(None, description="Creation timestamp")
+    updated_at: Optional[datetime] = Field(None, description="Update timestamp")
+
+    class Config:
+        from_attributes = True
+
+
+class AgentService:
+    """Service exposing agent-related operations."""
+
+    DEFAULT_AGENT_ID = "default-agent"
+
+    def __init__(self) -> None:
+        self.store = AgentStore()
+        self.test_case_store = TestCaseStore()
+
+    def ensure_default_agent_exists(self) -> Agent:
+        """Ensure the default agent exists and return it."""
+
+        agent = self.store.get_by_id(self.DEFAULT_AGENT_ID, include_deleted=True)
+        if agent:
+            if agent.is_deleted:
+                agent.is_deleted = False
+                agent = self.store.update(agent)
+            return agent
+
+        logger.info("Creating default agent for legacy data")
+        default_agent = Agent(
+            id=self.DEFAULT_AGENT_ID,
+            name="Default Agent",
+            description="System generated default agent",
+            default_model_name=None,
+            default_system_prompt=None,
+            default_model_settings=None,
+            is_deleted=False,
+        )
+        return self.store.create(default_agent)
+
+    def create_agent(self, data: AgentCreateData) -> AgentData:
+        """Create a new agent."""
+
+        agent = Agent(
+            id=str(uuid.uuid4()),
+            name=data.name,
+            description=data.description,
+            default_model_name=data.default_model_name,
+            default_system_prompt=data.default_system_prompt,
+            default_model_settings=data.default_model_settings,
+            is_deleted=False,
+        )
+        created = self.store.create(agent)
+        return AgentData.model_validate(created)
+
+    def get_agent(
+        self, agent_id: str, include_deleted: bool = False
+    ) -> Optional[AgentData]:
+        agent = self.store.get_by_id(agent_id, include_deleted=include_deleted)
+        if not agent:
+            return None
+        return AgentData.model_validate(agent)
+
+    def list_agents(self, include_deleted: bool = False) -> List[AgentData]:
+        agents = self.store.list_agents(include_deleted=include_deleted)
+        return [AgentData.model_validate(agent) for agent in agents]
+
+    def update_agent(self, agent_id: str, data: AgentUpdateData) -> Optional[AgentData]:
+        agent = self.store.get_by_id(agent_id, include_deleted=True)
+        if not agent:
+            return None
+
+        if data.name is not None:
+            agent.name = data.name
+        if data.description is not None:
+            agent.description = data.description
+        if data.default_model_name is not None:
+            agent.default_model_name = data.default_model_name
+        if data.default_system_prompt is not None:
+            agent.default_system_prompt = data.default_system_prompt
+        if data.default_model_settings is not None:
+            agent.default_model_settings = data.default_model_settings
+        if data.is_deleted is not None:
+            agent.is_deleted = data.is_deleted
+
+        updated = self.store.update(agent)
+        return AgentData.model_validate(updated)
+
+    def delete_agent(self, agent_id: str) -> bool:
+        """Soft delete an agent and cascade to its test cases."""
+
+        deleted = self.store.soft_delete(agent_id)
+        if not deleted:
+            return False
+        self.test_case_store.soft_delete_by_agent(agent_id)
+        return True
+
+    def restore_agent(self, agent_id: str) -> bool:
+        """Restore a previously soft-deleted agent."""
+
+        restored = self.store.restore(agent_id)
+        return restored
+
+    def get_agent_summary(self, agent_id: str) -> Optional[AgentSummary]:
+        agent = self.store.get_by_id(agent_id, include_deleted=True)
+        if not agent:
+            return None
+        return AgentSummary.model_validate(agent)
+
+    def get_active_agent_or_raise(self, agent_id: str) -> Agent:
+        agent = self.store.get_by_id(agent_id, include_deleted=True)
+        if not agent or agent.is_deleted:
+            raise ValueError(f"Agent not found or inactive: {agent_id}")
+        return agent
+
+
+__all__ = [
+    "AgentService",
+    "AgentCreateData",
+    "AgentUpdateData",
+    "AgentData",
+    "AgentSummary",
+]

--- a/src/services/agent_service.py
+++ b/src/services/agent_service.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.core.logger import get_logger
 from src.models import Agent
@@ -22,8 +22,7 @@ class AgentSummary(BaseModel):
     name: str = Field(..., description="Agent name")
     description: Optional[str] = Field(None, description="Agent description")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AgentCreateData(BaseModel):
@@ -79,8 +78,7 @@ class AgentData(BaseModel):
     created_at: Optional[datetime] = Field(None, description="Creation timestamp")
     updated_at: Optional[datetime] = Field(None, description="Update timestamp")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AgentService:

--- a/src/services/agent_service.py
+++ b/src/services/agent_service.py
@@ -86,34 +86,10 @@ class AgentData(BaseModel):
 class AgentService:
     """Service exposing agent-related operations."""
 
-    DEFAULT_AGENT_ID = "default-agent"
-
     def __init__(self) -> None:
         self.store = AgentStore()
         self.test_case_store = TestCaseStore()
         self.regression_test_store = RegressionTestStore()
-
-    def ensure_default_agent_exists(self) -> Agent:
-        """Ensure the default agent exists and return it."""
-
-        agent = self.store.get_by_id(self.DEFAULT_AGENT_ID, include_deleted=True)
-        if agent:
-            if agent.is_deleted:
-                agent.is_deleted = False
-                agent = self.store.update(agent)
-            return agent
-
-        logger.info("Creating default agent for legacy data")
-        default_agent = Agent(
-            id=self.DEFAULT_AGENT_ID,
-            name="Default Agent",
-            description="System generated default agent",
-            default_model_name=None,
-            default_system_prompt=None,
-            default_model_settings=None,
-            is_deleted=False,
-        )
-        return self.store.create(default_agent)
 
     def create_agent(self, data: AgentCreateData) -> AgentData:
         """Create a new agent."""

--- a/src/services/llm_parser_service.py
+++ b/src/services/llm_parser_service.py
@@ -5,56 +5,63 @@ Service for parsing logfire raw data and extracting LLM request components.
 """
 
 from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 from src.core.logger import get_logger
 
 logger = get_logger(__name__)
 
+
 class ParsedLLMData(BaseModel):
     """Parsed LLM data from raw logfire data for service layer use."""
 
     # Original data (used for replay concatenation)
-    middle_messages: List[Dict] = Field(..., description="Messages except system prompt and last user message")
+    middle_messages: List[Dict] = Field(
+        ..., description="Messages except system prompt and last user message"
+    )
     tools: Optional[List[Dict]] = Field(None, description="Tools configuration")
     model_name: str = Field(..., description="Model name")
-    model_settings: Optional[Dict] = Field(None, description="Model settings JSON (temperature, max_tokens, etc.)")
+    model_settings: Optional[Dict] = Field(
+        None, description="Model settings JSON (temperature, max_tokens, etc.)"
+    )
 
     # Parsed key data (used for page display and replay concatenation)
     system_prompt: str = Field(..., description="System prompt")
     last_user_message: str = Field(..., description="Last user message")
 
+
 def parse_llm_raw_data(raw_data: dict) -> ParsedLLMData:
     """
     Parse logfire raw data and separate system prompt, last user message, and other messages.
-    
+
     This function implements the optimized storage strategy where:
     - System prompt (first system message) is extracted separately
-    - Last user message is extracted separately  
+    - Last user message is extracted separately
     - All other messages are stored in original_messages for replay concatenation
-    
+
     Args:
         raw_data: Raw logfire data containing the LLM request
-        
+
     Returns:
         ParsedLLMData: Parsed data with separated components
-        
+
     Raises:
         ValueError: If raw data format is invalid
         KeyError: If required fields are missing
     """
     try:
         logger.debug("Parsing LLM raw data")
-        
+
         # Extract the request body from logfire data
         attributes = raw_data.get("attributes", {})
         if not attributes:
             raise ValueError("Missing 'attributes' in raw data")
-            
+
         request_body = attributes.get("http.request.body.text", {})
         if not request_body:
             raise ValueError("Missing 'http.request.body.text' in raw data")
-        
+
         # Extract original data
         all_messages = request_body.get("messages", [])
         tools = request_body.get("tools", [])
@@ -64,8 +71,14 @@ def parse_llm_raw_data(raw_data: dict) -> ParsedLLMData:
         model_settings = {}
 
         # Direct mapping for most parameters
-        for key in ["temperature", "top_p", "parallel_tool_calls",
-                   "seed", "presence_penalty", "frequency_penalty"]:
+        for key in [
+            "temperature",
+            "top_p",
+            "parallel_tool_calls",
+            "seed",
+            "presence_penalty",
+            "frequency_penalty",
+        ]:
             if key in request_body:
                 model_settings[key] = request_body[key]
 
@@ -84,7 +97,7 @@ def parse_llm_raw_data(raw_data: dict) -> ParsedLLMData:
             raise ValueError("No model specified in request body")
 
         logger.debug(f"Found {len(all_messages)} messages, model: {model_name}")
-        
+
         # Find and extract the first system message
         system_prompt = ""
         system_message_index = -1
@@ -94,7 +107,7 @@ def parse_llm_raw_data(raw_data: dict) -> ParsedLLMData:
                 system_message_index = i
                 logger.debug(f"Found system message at index {i}")
                 break
-        
+
         # Find and extract the last user message
         last_user_message = ""
         last_user_message_index = -1
@@ -104,7 +117,7 @@ def parse_llm_raw_data(raw_data: dict) -> ParsedLLMData:
                 last_user_message_index = i
                 logger.debug(f"Found last user message at index {i}")
                 break
-        
+
         # Build middle_messages (all messages except first system and last user)
         middle_messages = []
         for i, message in enumerate(all_messages):
@@ -125,9 +138,9 @@ def parse_llm_raw_data(raw_data: dict) -> ParsedLLMData:
             model_name=model_name,
             model_settings=model_settings,
             system_prompt=system_prompt,
-            last_user_message=last_user_message
+            last_user_message=last_user_message,
         )
-        
+
     except (KeyError, ValueError) as e:
         logger.error(f"Failed to parse LLM raw data: {e}")
         raise ValueError(f"Invalid raw data format: {str(e)}") from e
@@ -139,10 +152,10 @@ def parse_llm_raw_data(raw_data: dict) -> ParsedLLMData:
 def validate_raw_data_format(raw_data: dict) -> bool:
     """
     Validate that raw data has the expected logfire format.
-    
+
     Args:
         raw_data: Raw data to validate
-        
+
     Returns:
         bool: True if format is valid
     """
@@ -150,24 +163,24 @@ def validate_raw_data_format(raw_data: dict) -> bool:
         # Check basic structure
         if not isinstance(raw_data, dict):
             return False
-            
+
         attributes = raw_data.get("attributes")
         if not isinstance(attributes, dict):
             return False
-            
+
         request_body = attributes.get("http.request.body.text")
         if not isinstance(request_body, dict):
             return False
-            
+
         # Check required fields
         messages = request_body.get("messages")
         if not isinstance(messages, list) or not messages:
             return False
-            
+
         model = request_body.get("model")
         if not isinstance(model, str) or not model:
             return False
-            
+
         # Validate message format
         for message in messages:
             if not isinstance(message, dict):
@@ -176,10 +189,10 @@ def validate_raw_data_format(raw_data: dict) -> bool:
                 return False
             if message["role"] not in ["system", "user", "assistant", "tool"]:
                 return False
-                
+
         logger.debug("Raw data format validation passed")
         return True
-        
+
     except Exception as e:
         logger.debug(f"Raw data format validation failed: {e}")
         return False
@@ -188,37 +201,35 @@ def validate_raw_data_format(raw_data: dict) -> bool:
 def extract_model_info(raw_data: dict) -> Dict[str, str]:
     """
     Extract model information from raw data.
-    
+
     Args:
         raw_data: Raw logfire data
-        
+
     Returns:
         Dict with model information
     """
     try:
         attributes = raw_data.get("attributes", {})
         request_body = attributes.get("http.request.body.text", {})
-        
+
         model_name = request_body.get("model", "")
-        
+
         # Extract provider from model name if it follows provider:model format
         provider = ""
         if ":" in model_name:
             provider = model_name.split(":", 1)[0]
-        
+
         return {
             "full_model_name": model_name,
             "provider": provider,
-            "model_only": model_name.split(":", 1)[-1] if ":" in model_name else model_name
+            "model_only": (
+                model_name.split(":", 1)[-1] if ":" in model_name else model_name
+            ),
         }
-        
+
     except Exception as e:
         logger.error(f"Failed to extract model info: {e}")
-        return {
-            "full_model_name": "",
-            "provider": "",
-            "model_only": ""
-        }
+        return {"full_model_name": "", "provider": "", "model_only": ""}
 
 
 __all__ = ["parse_llm_raw_data", "validate_raw_data_format", "extract_model_info"]

--- a/src/services/regression_test_service.py
+++ b/src/services/regression_test_service.py
@@ -25,9 +25,11 @@ class RegressionTestCreateData(BaseModel):
     """Input payload for launching a regression test."""
 
     agent_id: str = Field(..., description="Agent under test")
-    model_name: str = Field(..., description="Model name override for this regression")
-    system_prompt: str = Field(..., description="System prompt override")
-    model_settings: Dict = Field(
+    model_name_override: str = Field(
+        ..., description="Model name override for this regression"
+    )
+    system_prompt_override: str = Field(..., description="System prompt override")
+    model_settings_override: Dict = Field(
         default_factory=dict, description="Model settings override JSON"
     )
 
@@ -79,9 +81,9 @@ class RegressionTestService:
             id=str(uuid.uuid4()),
             agent_id=agent.id,
             status="running",
-            model_name_override=request.model_name,
-            system_prompt_override=request.system_prompt,
-            model_settings_override=request.model_settings,
+            model_name_override=request.model_name_override,
+            system_prompt_override=request.system_prompt_override,
+            model_settings_override=request.model_settings_override,
             total_count=len(test_cases),
             success_count=0,
             failed_count=0,
@@ -114,9 +116,9 @@ class RegressionTestService:
                         test_case_id=case.id,
                         agent_id=agent.id,
                         regression_test_id=regression.id,
-                        modified_model_name=request.model_name,
-                        modified_system_prompt=request.system_prompt,
-                        modified_model_settings=request.model_settings,
+                        modified_model_name=request.model_name_override,
+                        modified_system_prompt=request.system_prompt_override,
+                        modified_model_settings=request.model_settings_override,
                     )
                     result = await self.test_execution_service.execute_test(
                         execution_request

--- a/src/services/regression_test_service.py
+++ b/src/services/regression_test_service.py
@@ -12,8 +12,8 @@ from src.models import RegressionTest
 from src.services.agent_service import AgentService, AgentSummary
 from src.services.test_case_service import TestCaseService
 from src.services.test_execution_service import (
-    TestExecutionData,
     ExecutionResult,
+    TestExecutionData,
     TestExecutionService,
 )
 from src.stores.regression_test_store import RegressionTestStore

--- a/src/services/regression_test_service.py
+++ b/src/services/regression_test_service.py
@@ -1,0 +1,220 @@
+"""Service orchestrating regression test executions."""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from src.core.logger import get_logger
+from src.models import RegressionTest
+from src.services.agent_service import AgentService, AgentSummary
+from src.services.test_case_service import TestCaseService
+from src.services.test_execution_service import (
+    TestExecutionData,
+    TestExecutionResult,
+    TestExecutionService,
+)
+from src.stores.regression_test_store import RegressionTestStore
+
+logger = get_logger(__name__)
+
+
+class RegressionTestCreateData(BaseModel):
+    """Input payload for launching a regression test."""
+
+    agent_id: str = Field(..., description="Agent under test")
+    model_name: str = Field(..., description="Model name override for this regression")
+    system_prompt: str = Field(..., description="System prompt override")
+    model_settings: Dict = Field(
+        default_factory=dict, description="Model settings override JSON"
+    )
+
+
+class RegressionTestData(BaseModel):
+    """Service representation of a regression test record."""
+
+    id: str
+    agent_id: str
+    status: str
+    model_name_override: str
+    system_prompt_override: str
+    model_settings_override: Dict
+    total_count: int
+    success_count: int
+    failed_count: int
+    error_message: Optional[str]
+    started_at: Optional[datetime]
+    completed_at: Optional[datetime]
+    created_at: datetime
+    updated_at: datetime
+    agent: Optional[AgentSummary] = None
+
+    class Config:
+        from_attributes = True
+
+
+class RegressionTestService:
+    """Coordinates regression execution across all test cases for an agent."""
+
+    MAX_CONCURRENCY = 5
+
+    def __init__(self) -> None:
+        self.agent_service = AgentService()
+        self.test_case_service = TestCaseService()
+        self.test_execution_service = TestExecutionService()
+        self.store = RegressionTestStore()
+
+    async def run_regression_test(
+        self, request: RegressionTestCreateData
+    ) -> RegressionTestData:
+        """Create and execute a regression test for an agent."""
+
+        agent = self.agent_service.get_active_agent_or_raise(request.agent_id)
+        agent_summary = AgentSummary.model_validate(agent)
+        test_cases = self.test_case_service.store.get_by_agent(agent.id)
+
+        regression = RegressionTest(
+            id=str(uuid.uuid4()),
+            agent_id=agent.id,
+            status="running",
+            model_name_override=request.model_name,
+            system_prompt_override=request.system_prompt,
+            model_settings_override=request.model_settings,
+            total_count=len(test_cases),
+            success_count=0,
+            failed_count=0,
+            error_message=None,
+            started_at=datetime.now(timezone.utc),
+            completed_at=None,
+        )
+
+        regression = self.store.create(regression)
+
+        if not test_cases:
+            logger.info(
+                "No test cases available for agent %s; marking regression %s as completed",
+                agent.id,
+                regression.id,
+            )
+            regression.status = "completed"
+            regression.completed_at = datetime.now(timezone.utc)
+            regression = self.store.update(regression)
+            return self._build_regression_test_data(regression, agent_summary)
+
+        semaphore = asyncio.Semaphore(self.MAX_CONCURRENCY)
+        results: List[TestExecutionResult] = []
+        execution_errors: List[str] = []
+
+        async def execute_case(case) -> None:
+            async with semaphore:
+                try:
+                    execution_request = TestExecutionData(
+                        test_case_id=case.id,
+                        agent_id=agent.id,
+                        regression_test_id=regression.id,
+                        modified_model_name=request.model_name,
+                        modified_system_prompt=request.system_prompt,
+                        modified_model_settings=request.model_settings,
+                    )
+                    result = await self.test_execution_service.execute_test(
+                        execution_request
+                    )
+                    results.append(result)
+                except Exception as execution_error:  # pragma: no cover - defensive
+                    logger.error(
+                        "Regression %s execution failed for case %s: %s",
+                        regression.id,
+                        case.id,
+                        execution_error,
+                    )
+                    execution_errors.append(str(execution_error))
+
+        await asyncio.gather(*(execute_case(case) for case in test_cases))
+
+        success_count = sum(1 for result in results if result.status == "success")
+        failed_count = len(test_cases) - success_count
+
+        if execution_errors:
+            # Account for cases that raised exceptions and didn't yield results
+            failed_count = max(failed_count, len(execution_errors))
+
+        regression.success_count = success_count
+        regression.failed_count = failed_count
+        has_failures = failed_count > 0
+        regression.status = (
+            "failed" if (execution_errors or has_failures) else "completed"
+        )
+        regression.error_message = (
+            "; ".join(execution_errors) if execution_errors else None
+        )
+        regression.completed_at = datetime.now(timezone.utc)
+
+        regression = self.store.update(regression)
+        return self._build_regression_test_data(regression, agent_summary)
+
+    def get_regression_test(
+        self, regression_test_id: str
+    ) -> Optional[RegressionTestData]:
+        record = self.store.get_by_id(regression_test_id)
+        if not record:
+            return None
+        agent_summary = self.agent_service.get_agent_summary(record.agent_id)
+        return self._build_regression_test_data(record, agent_summary)
+
+    def list_regression_tests(
+        self,
+        *,
+        agent_id: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[RegressionTestData]:
+        records = self.store.list_regression_tests(
+            agent_id=agent_id, status=status, limit=limit, offset=offset
+        )
+        agent_cache: Dict[str, AgentSummary] = {}
+        data: List[RegressionTestData] = []
+        for record in records:
+            if record.agent_id not in agent_cache:
+                agent_cache[record.agent_id] = self.agent_service.get_agent_summary(
+                    record.agent_id
+                )
+            data.append(
+                self._build_regression_test_data(record, agent_cache[record.agent_id])
+            )
+        return data
+
+    def _build_regression_test_data(
+        self,
+        regression: RegressionTest,
+        agent_summary: Optional[AgentSummary] = None,
+    ) -> RegressionTestData:
+        if agent_summary is None:
+            agent_summary = self.agent_service.get_agent_summary(regression.agent_id)
+
+        return RegressionTestData(
+            id=regression.id,
+            agent_id=regression.agent_id,
+            status=regression.status,
+            model_name_override=regression.model_name_override,
+            system_prompt_override=regression.system_prompt_override,
+            model_settings_override=regression.model_settings_override,
+            total_count=regression.total_count,
+            success_count=regression.success_count,
+            failed_count=regression.failed_count,
+            error_message=regression.error_message,
+            started_at=regression.started_at,
+            completed_at=regression.completed_at,
+            created_at=regression.created_at,
+            updated_at=regression.updated_at,
+            agent=agent_summary,
+        )
+
+
+__all__ = [
+    "RegressionTestService",
+    "RegressionTestCreateData",
+    "RegressionTestData",
+]

--- a/src/services/task_dispatcher.py
+++ b/src/services/task_dispatcher.py
@@ -1,0 +1,39 @@
+"""Task dispatch utilities for background execution.
+
+These abstractions allow the application to swap out the underlying task
+execution mechanism (FastAPI background tasks, Celery, etc.) without changing
+the service layer.
+"""
+
+from fastapi import BackgroundTasks
+
+
+class RegressionTaskDispatcher:
+    """Interface for scheduling regression execution jobs."""
+
+    def dispatch(self, regression_id: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class BackgroundTaskRegressionDispatcher(RegressionTaskDispatcher):
+    """Dispatcher that leverages FastAPI BackgroundTasks."""
+
+    def __init__(
+        self,
+        background_tasks: BackgroundTasks,
+        execute_callable,
+    ) -> None:
+        self._background_tasks = background_tasks
+        self._execute_callable = execute_callable
+
+    def dispatch(self, regression_id: str) -> None:
+        """Schedule regression execution using FastAPI background tasks."""
+
+        self._background_tasks.add_task(self._execute_callable, regression_id)
+
+
+__all__ = [
+    "RegressionTaskDispatcher",
+    "BackgroundTaskRegressionDispatcher",
+]
+

--- a/src/services/task_dispatcher.py
+++ b/src/services/task_dispatcher.py
@@ -36,4 +36,3 @@ __all__ = [
     "RegressionTaskDispatcher",
     "BackgroundTaskRegressionDispatcher",
 ]
-

--- a/src/services/test_case_service.py
+++ b/src/services/test_case_service.py
@@ -218,7 +218,9 @@ class TestCaseService:
             # Change agent if requested
             if request.agent_id is not None and request.agent_id != test_case.agent_id:
                 try:
-                    agent = self.agent_service.get_active_agent_or_raise(request.agent_id)
+                    agent = self.agent_service.get_active_agent_or_raise(
+                        request.agent_id
+                    )
                 except ValueError as agent_error:
                     logger.error("Invalid agent specified on update: %s", agent_error)
                     raise

--- a/src/services/test_case_service.py
+++ b/src/services/test_case_service.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.core.logger import get_logger
 from src.models import TestCase
@@ -65,8 +65,7 @@ class TestCaseData(BaseModel):
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TestCaseService:

--- a/src/services/test_case_service.py
+++ b/src/services/test_case_service.py
@@ -26,7 +26,7 @@ class TestCaseCreateData(BaseModel):
     name: str = Field(..., description="Test case name")
     raw_data: Dict = Field(..., description="Raw logfire data")
     description: Optional[str] = Field(None, description="Test case description")
-    agent_id: Optional[str] = Field(None, description="Agent that owns this test case")
+    agent_id: str = Field(..., description="Agent that owns this test case")
 
 
 class TestCaseUpdateData(BaseModel):

--- a/src/services/test_case_service.py
+++ b/src/services/test_case_service.py
@@ -75,8 +75,6 @@ class TestCaseService:
     def __init__(self):
         self.store = TestCaseStore()
         self.agent_service = AgentService()
-        # Ensure there is always a default agent for legacy data paths
-        self.agent_service.ensure_default_agent_exists()
 
     def create_test_case(self, request: TestCaseCreateData) -> TestCaseData:
         """
@@ -104,11 +102,7 @@ class TestCaseService:
 
             # Resolve agent
             try:
-                agent = (
-                    self.agent_service.get_active_agent_or_raise(request.agent_id)
-                    if request.agent_id
-                    else self.agent_service.ensure_default_agent_exists()
-                )
+                agent = self.agent_service.get_active_agent_or_raise(request.agent_id)
             except ValueError as agent_error:
                 logger.error("Invalid agent specified: %s", agent_error)
                 raise
@@ -225,9 +219,7 @@ class TestCaseService:
             # Change agent if requested
             if request.agent_id is not None and request.agent_id != test_case.agent_id:
                 try:
-                    agent = self.agent_service.get_active_agent_or_raise(
-                        request.agent_id
-                    )
+                    agent = self.agent_service.get_active_agent_or_raise(request.agent_id)
                 except ValueError as agent_error:
                     logger.error("Invalid agent specified on update: %s", agent_error)
                     raise

--- a/src/services/test_case_service.py
+++ b/src/services/test_case_service.py
@@ -363,8 +363,14 @@ class TestCaseService:
         """Convert a TestCase ORM instance to TestCaseData."""
 
         agent_summary = None
-        if getattr(test_case, "agent", None):
-            agent_summary = AgentSummary.model_validate(test_case.agent)
+        agent_value = None
+
+        # Avoid triggering lazy loads on detached instances
+        if hasattr(test_case, "__dict__") and "agent" in test_case.__dict__:
+            agent_value = test_case.__dict__["agent"]
+
+        if agent_value is not None:
+            agent_summary = AgentSummary.model_validate(agent_value)
         else:
             agent_summary = self.agent_service.get_agent_summary(test_case.agent_id)
 

--- a/src/services/test_case_service.py
+++ b/src/services/test_case_service.py
@@ -5,33 +5,42 @@ Business logic service for test case operations.
 Handles creation, retrieval, updating, and deletion of test cases with parsing.
 """
 
-from datetime import datetime
 import uuid
+from datetime import datetime
 from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 from src.core.logger import get_logger
 from src.models import TestCase
+from src.services.agent_service import AgentService, AgentSummary
 from src.services.llm_parser_service import parse_llm_raw_data, validate_raw_data_format
 from src.stores.test_case_store import TestCaseStore
 
 logger = get_logger(__name__)
 
+
 class TestCaseCreateData(BaseModel):
     """Service layer data for creating a test case."""
-    
+
     name: str = Field(..., description="Test case name")
     raw_data: Dict = Field(..., description="Raw logfire data")
     description: Optional[str] = Field(None, description="Test case description")
+    agent_id: Optional[str] = Field(None, description="Agent that owns this test case")
+
 
 class TestCaseUpdateData(BaseModel):
     """Service layer data for updating a test case."""
 
     name: Optional[str] = Field(None, description="Updated test case name")
     raw_data: Optional[Dict] = Field(None, description="Updated raw logfire data")
-    description: Optional[str] = Field(None, description="Updated test case description")
+    description: Optional[str] = Field(
+        None, description="Updated test case description"
+    )
     system_prompt: Optional[str] = Field(None, description="Updated system prompt")
     last_user_message: Optional[str] = Field(None, description="Updated user message")
+    agent_id: Optional[str] = Field(None, description="Updated owning agent")
+
 
 class TestCaseData(BaseModel):
     """Service layer representation of a test case."""
@@ -46,10 +55,16 @@ class TestCaseData(BaseModel):
     model_settings: Optional[Dict] = Field(None, description="Model settings JSON")
     system_prompt: str = Field(..., description="System prompt")
     last_user_message: str = Field(..., description="Last user message")
-    is_deleted: bool = Field(False, description="Indicates whether the test case is soft deleted")
+    agent_id: str = Field(..., description="Owning agent identifier")
+    agent: Optional[AgentSummary] = Field(
+        None, description="Summary information about the owning agent"
+    )
+    is_deleted: bool = Field(
+        False, description="Indicates whether the test case is soft deleted"
+    )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
-    
+
     class Config:
         from_attributes = True
 
@@ -59,34 +74,49 @@ class TestCaseService:
 
     def __init__(self):
         self.store = TestCaseStore()
+        self.agent_service = AgentService()
+        # Ensure there is always a default agent for legacy data paths
+        self.agent_service.ensure_default_agent_exists()
 
     def create_test_case(self, request: TestCaseCreateData) -> TestCaseData:
         """
         Create a new test case with automatic parsing of raw data.
-        
+
         Args:
             request: Test case creation request
-            
+
         Returns:
             TestCaseData: Created test case data
-            
+
         Raises:
             ValueError: If raw data is invalid
             Exception: If creation fails
         """
         try:
             logger.info(f"Creating test case: {request.name}")
-            
+
             # Validate raw data format
             if not validate_raw_data_format(request.raw_data):
                 raise ValueError("Invalid raw data format")
-            
+
             # Parse the raw data
             parsed_data = parse_llm_raw_data(request.raw_data)
-            
+
+            # Resolve agent
+            try:
+                agent = (
+                    self.agent_service.get_active_agent_or_raise(request.agent_id)
+                    if request.agent_id
+                    else self.agent_service.ensure_default_agent_exists()
+                )
+            except ValueError as agent_error:
+                logger.error("Invalid agent specified: %s", agent_error)
+                raise
+
             # Create test case model
             test_case = TestCase(
                 id=str(uuid.uuid4()),
+                agent_id=agent.id,
                 name=request.name,
                 description=request.description,
                 raw_data=request.raw_data,
@@ -96,30 +126,16 @@ class TestCaseService:
                 model_settings=parsed_data.model_settings,
                 system_prompt=parsed_data.system_prompt,
                 last_user_message=parsed_data.last_user_message,
-                is_deleted=False
+                is_deleted=False,
             )
-            
+
             # Save to database
             created_test_case = self.store.create(test_case)
-            
-            logger.info(f"Test case created successfully: {created_test_case.id}")
-            
-            return TestCaseData(
-                id=created_test_case.id,
-                name=created_test_case.name,
-                description=created_test_case.description,
-                raw_data=created_test_case.raw_data,
-                middle_messages=created_test_case.middle_messages,
-                tools=created_test_case.tools,
-                model_name=created_test_case.model_name,
-                model_settings=created_test_case.model_settings,
-                system_prompt=created_test_case.system_prompt,
-                last_user_message=created_test_case.last_user_message,
-                is_deleted=created_test_case.is_deleted,
-                created_at=created_test_case.created_at,
-                updated_at=created_test_case.updated_at
-            )
-            
+
+            logger.info("Test case created successfully: %s", created_test_case.id)
+
+            return self._build_test_case_data(created_test_case)
+
         except ValueError as e:
             logger.error(f"Invalid data for test case creation: {e}")
             raise
@@ -130,10 +146,10 @@ class TestCaseService:
     def get_test_case(self, test_case_id: str) -> Optional[TestCaseData]:
         """
         Get a test case by ID.
-        
+
         Args:
             test_case_id: Test case ID
-            
+
         Returns:
             TestCaseData or None if not found
         """
@@ -146,64 +162,42 @@ class TestCaseService:
             if test_case.is_deleted:
                 logger.debug(f"Test case is marked as deleted: {test_case_id}")
 
-            return TestCaseData(
-                id=test_case.id,
-                name=test_case.name,
-                description=test_case.description,
-                raw_data=test_case.raw_data,
-                middle_messages=test_case.middle_messages,
-                tools=test_case.tools,
-                model_name=test_case.model_name,
-                model_settings=test_case.model_settings,
-                system_prompt=test_case.system_prompt,
-                last_user_message=test_case.last_user_message,
-                is_deleted=test_case.is_deleted,
-                created_at=test_case.created_at,
-                updated_at=test_case.updated_at
-            )
-            
+            return self._build_test_case_data(test_case)
+
         except Exception as e:
             logger.error(f"Failed to get test case {test_case_id}: {e}")
             raise
 
-    def get_all_test_cases(self, limit: int = 100, offset: int = 0) -> List[TestCaseData]:
+    def get_all_test_cases(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        agent_id: Optional[str] = None,
+    ) -> List[TestCaseData]:
         """
         Get all test cases with pagination.
-        
+
         Args:
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of test case responses
         """
         try:
-            test_cases = self.store.get_all(limit=limit, offset=offset)
-            
-            return [
-                TestCaseData(
-                    id=tc.id,
-                    name=tc.name,
-                    description=tc.description,
-                    raw_data=tc.raw_data,
-                    middle_messages=tc.middle_messages,
-                    tools=tc.tools,
-                    model_name=tc.model_name,
-                    model_settings=tc.model_settings,
-                    system_prompt=tc.system_prompt,
-                    last_user_message=tc.last_user_message,
-                    is_deleted=tc.is_deleted,
-                    created_at=tc.created_at,
-                    updated_at=tc.updated_at
-                )
-                for tc in test_cases
-            ]
-            
+            test_cases = self.store.get_all(
+                limit=limit, offset=offset, agent_id=agent_id
+            )
+
+            return [self._build_test_case_data(tc) for tc in test_cases]
+
         except Exception as e:
             logger.error(f"Failed to get test cases: {e}")
             raise
 
-    def update_test_case(self, test_case_id: str, request: TestCaseUpdateData) -> Optional[TestCaseData]:
+    def update_test_case(
+        self, test_case_id: str, request: TestCaseUpdateData
+    ) -> Optional[TestCaseData]:
         """
         Update an existing test case.
 
@@ -228,6 +222,17 @@ class TestCaseService:
                 logger.debug(f"Cannot update deleted test case: {test_case_id}")
                 return None
 
+            # Change agent if requested
+            if request.agent_id is not None and request.agent_id != test_case.agent_id:
+                try:
+                    agent = self.agent_service.get_active_agent_or_raise(
+                        request.agent_id
+                    )
+                except ValueError as agent_error:
+                    logger.error("Invalid agent specified on update: %s", agent_error)
+                    raise
+                test_case.agent_id = agent.id
+
             # If raw_data is provided, re-parse it and update all parsed fields
             if request.raw_data is not None:
                 logger.info(f"Re-importing raw data for test case: {test_case_id}")
@@ -248,7 +253,9 @@ class TestCaseService:
                 test_case.system_prompt = parsed_data.system_prompt
                 test_case.last_user_message = parsed_data.last_user_message
 
-                logger.info(f"Raw data re-parsed successfully for test case: {test_case_id}")
+                logger.info(
+                    f"Raw data re-parsed successfully for test case: {test_case_id}"
+                )
 
             # Update other fields if provided
             if request.name is not None:
@@ -265,25 +272,11 @@ class TestCaseService:
 
             # Save changes
             updated_test_case = self.store.update(test_case)
-            
+
             logger.info(f"Test case updated successfully: {test_case_id}")
-            
-            return TestCaseData(
-                id=updated_test_case.id,
-                name=updated_test_case.name,
-                description=updated_test_case.description,
-                raw_data=updated_test_case.raw_data,
-                middle_messages=updated_test_case.middle_messages,
-                tools=updated_test_case.tools,
-                model_name=updated_test_case.model_name,
-                model_settings=updated_test_case.model_settings,
-                system_prompt=updated_test_case.system_prompt,
-                last_user_message=updated_test_case.last_user_message,
-                is_deleted=updated_test_case.is_deleted,
-                created_at=updated_test_case.created_at,
-                updated_at=updated_test_case.updated_at
-            )
-            
+
+            return self._build_test_case_data(updated_test_case)
+
         except Exception as e:
             logger.error(f"Failed to update test case {test_case_id}: {e}")
             raise
@@ -305,44 +298,31 @@ class TestCaseService:
             else:
                 logger.debug(f"Test case not found for deletion: {test_case_id}")
             return deleted
-            
+
         except Exception as e:
             logger.error(f"Failed to delete test case {test_case_id}: {e}")
             raise
 
-    def search_test_cases(self, name_pattern: str, limit: int = 50) -> List[TestCaseData]:
+    def search_test_cases(
+        self, name_pattern: str, limit: int = 50, agent_id: Optional[str] = None
+    ) -> List[TestCaseData]:
         """
         Search test cases by name pattern.
-        
+
         Args:
             name_pattern: Pattern to search for in names
             limit: Maximum number of results
-            
+
         Returns:
             List of matching test case responses
         """
         try:
-            test_cases = self.store.search_by_name(name_pattern, limit=limit)
-            
-            return [
-                TestCaseData(
-                    id=tc.id,
-                    name=tc.name,
-                    description=tc.description,
-                    raw_data=tc.raw_data,
-                    middle_messages=tc.middle_messages,
-                    tools=tc.tools,
-                    model_name=tc.model_name,
-                    model_settings=tc.model_settings,
-                    system_prompt=tc.system_prompt,
-                    last_user_message=tc.last_user_message,
-                    is_deleted=tc.is_deleted,
-                    created_at=tc.created_at,
-                    updated_at=tc.updated_at
-                )
-                for tc in test_cases
-            ]
-            
+            test_cases = self.store.search_by_name(
+                name_pattern, limit=limit, agent_id=agent_id
+            )
+
+            return [self._build_test_case_data(tc) for tc in test_cases]
+
         except Exception as e:
             logger.error(f"Failed to search test cases: {e}")
             raise
@@ -364,11 +344,47 @@ class TestCaseService:
                     f"Test case {test_case_id} is marked as deleted; skipping execution"
                 )
                 return None
+            if test_case:
+                try:
+                    self.agent_service.get_active_agent_or_raise(test_case.agent_id)
+                except ValueError:
+                    logger.debug(
+                        "Test case %s belongs to inactive agent; skipping execution",
+                        test_case_id,
+                    )
+                    return None
             return test_case
 
         except Exception as e:
             logger.error(f"Failed to get test case for execution {test_case_id}: {e}")
             raise
+
+    def _build_test_case_data(self, test_case: TestCase) -> TestCaseData:
+        """Convert a TestCase ORM instance to TestCaseData."""
+
+        agent_summary = None
+        if getattr(test_case, "agent", None):
+            agent_summary = AgentSummary.model_validate(test_case.agent)
+        else:
+            agent_summary = self.agent_service.get_agent_summary(test_case.agent_id)
+
+        return TestCaseData(
+            id=test_case.id,
+            name=test_case.name,
+            description=test_case.description,
+            raw_data=test_case.raw_data,
+            middle_messages=test_case.middle_messages,
+            tools=test_case.tools,
+            model_name=test_case.model_name,
+            model_settings=test_case.model_settings,
+            system_prompt=test_case.system_prompt,
+            last_user_message=test_case.last_user_message,
+            agent_id=test_case.agent_id,
+            agent=agent_summary,
+            is_deleted=test_case.is_deleted,
+            created_at=test_case.created_at,
+            updated_at=test_case.updated_at,
+        )
 
 
 __all__ = ["TestCaseService"]

--- a/src/services/test_execution_service.py
+++ b/src/services/test_execution_service.py
@@ -4,43 +4,73 @@ Test Execution Service
 Service for executing LLM tests synchronously and recording results.
 """
 
-from datetime import datetime
 import time
 import uuid
+from datetime import datetime
 from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 from src.core.logger import get_logger
 from src.models import TestLog
+from src.services.agent_service import AgentService
 from src.services.llm_execution_service import execute_llm_test
 from src.services.test_case_service import TestCaseService
 from src.stores.test_log_store import TestLogStore
 
 logger = get_logger(__name__)
 
+
 class TestExecutionData(BaseModel):
     """Service layer data for test execution."""
 
     test_case_id: str = Field(..., description="ID of the test case to execute")
+    agent_id: Optional[str] = Field(
+        None, description="Agent context overriding the test case owner"
+    )
+    regression_test_id: Optional[str] = Field(
+        None, description="Regression test run triggering this execution"
+    )
     # User may modify these parameters (if None, use original values)
     modified_model_name: Optional[str] = Field(None, description="Override model name")
-    modified_system_prompt: Optional[str] = Field(None, description="Override system prompt")
-    modified_last_user_message: Optional[str] = Field(None, description="Override user message")
-    modified_tools: Optional[List[Dict]] = Field(None, description="Override tools configuration")
-    modified_model_settings: Optional[Dict] = Field(None, description="Override model settings JSON")
+    modified_system_prompt: Optional[str] = Field(
+        None, description="Override system prompt"
+    )
+    modified_last_user_message: Optional[str] = Field(
+        None, description="Override user message"
+    )
+    modified_tools: Optional[List[Dict]] = Field(
+        None, description="Override tools configuration"
+    )
+    modified_model_settings: Optional[Dict] = Field(
+        None, description="Override model settings JSON"
+    )
+
 
 class TestExecutionResult(BaseModel):
     """Service layer result of test execution."""
 
     status: str = Field(..., description="Execution status (success/failed)")
-    log_id: Optional[str] = Field(None, description="Test log ID if execution completed")
-    response_time_ms: Optional[int] = Field(None, description="Response time in milliseconds")
+    log_id: Optional[str] = Field(
+        None, description="Test log ID if execution completed"
+    )
+    agent_id: Optional[str] = Field(None, description="Agent used for execution")
+    regression_test_id: Optional[str] = Field(
+        None, description="Regression test context for the execution"
+    )
+    response_time_ms: Optional[int] = Field(
+        None, description="Response time in milliseconds"
+    )
     executed_at: Optional[datetime] = Field(None, description="Execution timestamp")
-    error_message: Optional[str] = Field(None, description="Error message if execution failed")
+    error_message: Optional[str] = Field(
+        None, description="Error message if execution failed"
+    )
     llm_response: Optional[str] = Field(None, description="LLM response text")
-    
+
     # Additional service-layer specific fields
-    execution_context: Optional[Dict] = Field(None, description="Execution context data")
+    execution_context: Optional[Dict] = Field(
+        None, description="Execution context data"
+    )
     performance_metrics: Optional[Dict] = Field(None, description="Performance metrics")
 
 
@@ -50,44 +80,70 @@ class TestExecutionService:
     def __init__(self):
         self.test_case_service = TestCaseService()
         self.test_log_store = TestLogStore()
+        self.agent_service = AgentService()
 
     async def execute_test(self, request: TestExecutionData) -> TestExecutionResult:
         """
         Execute a test case synchronously and record the results.
-        
+
         Args:
             request: Test execution request
-            
+
         Returns:
             TestExecutionResult: Execution results
-            
+
         Raises:
             ValueError: If test case not found or invalid parameters
             Exception: If execution fails
         """
         try:
             logger.info(f"Executing test for case: {request.test_case_id}")
-            
+
             # Get test case data
-            test_case = self.test_case_service.get_test_case_for_execution(request.test_case_id)
+            test_case = self.test_case_service.get_test_case_for_execution(
+                request.test_case_id
+            )
             if not test_case:
                 raise ValueError(f"Test case not found: {request.test_case_id}")
-            
-            # Use provided parameters or fall back to test case defaults
-            model_name = request.modified_model_name or test_case.model_name
-            system_prompt = request.modified_system_prompt or test_case.system_prompt
-            user_message = request.modified_last_user_message or test_case.last_user_message
+
+            # Determine agent context
+            agent_identifier = request.agent_id or test_case.agent_id
+            try:
+                agent = self.agent_service.get_active_agent_or_raise(agent_identifier)
+            except ValueError as agent_error:
+                logger.error("Agent not available for execution: %s", agent_error)
+                raise ValueError(str(agent_error)) from agent_error
+
+            # Use provided parameters or fall back to test case defaults / agent defaults
+            model_name = (
+                request.modified_model_name
+                or test_case.model_name
+                or agent.default_model_name
+            )
+            system_prompt = (
+                request.modified_system_prompt
+                or test_case.system_prompt
+                or agent.default_system_prompt
+            )
+            user_message = (
+                request.modified_last_user_message or test_case.last_user_message
+            )
             tools = request.modified_tools or test_case.tools
-            model_settings = request.modified_model_settings if request.modified_model_settings is not None else test_case.model_settings
-            
+            if request.modified_model_settings is not None:
+                model_settings = request.modified_model_settings
+            elif test_case.model_settings is not None:
+                model_settings = test_case.model_settings
+            else:
+                model_settings = agent.default_model_settings
+
             if not model_name:
                 raise ValueError("No model name specified")
-            
+
             logger.debug(f"Executing with model: {model_name}")
-            
+
             # Record start time
             start_time = time.time()
-            
+
             # Execute the LLM test
             try:
                 llm_response = await execute_llm_test(
@@ -97,16 +153,18 @@ class TestExecutionService:
                     user_message=user_message,
                     original_tools=test_case.tools,
                     modified_tools=tools,
-                    model_settings=model_settings
+                    model_settings=model_settings,
                 )
-                
+
                 # Calculate response time
                 response_time_ms = int((time.time() - start_time) * 1000)
-                
+
                 # Create success log
                 test_log = TestLog(
                     id=str(uuid.uuid4()),
                     test_case_id=request.test_case_id,
+                    agent_id=agent.id,
+                    regression_test_id=request.regression_test_id,
                     model_name=model_name,
                     model_settings=model_settings,
                     system_prompt=system_prompt,
@@ -115,32 +173,36 @@ class TestExecutionService:
                     llm_response=llm_response,
                     response_time_ms=response_time_ms,
                     status="success",
-                    error_message=None
+                    error_message=None,
                 )
-                
+
                 # Save log
                 saved_log = self.test_log_store.create(test_log)
-                
+
                 logger.info(f"Test executed successfully: {saved_log.id}")
-                
+
                 return TestExecutionResult(
                     log_id=saved_log.id,
                     status="success",
+                    agent_id=agent.id,
+                    regression_test_id=request.regression_test_id,
                     llm_response=llm_response,
                     response_time_ms=response_time_ms,
                     error_message=None,
-                    executed_at=saved_log.created_at
+                    executed_at=saved_log.created_at,
                 )
-                
+
             except Exception as llm_error:
                 # Calculate response time even for failures
                 response_time_ms = int((time.time() - start_time) * 1000)
-                
+
                 # Create failure log
                 error_message = str(llm_error)
                 test_log = TestLog(
                     id=str(uuid.uuid4()),
                     test_case_id=request.test_case_id,
+                    agent_id=agent.id,
+                    regression_test_id=request.regression_test_id,
                     model_name=model_name,
                     model_settings=model_settings,
                     system_prompt=system_prompt,
@@ -149,23 +211,25 @@ class TestExecutionService:
                     llm_response=None,
                     response_time_ms=response_time_ms,
                     status="failed",
-                    error_message=error_message
+                    error_message=error_message,
                 )
-                
+
                 # Save log
                 saved_log = self.test_log_store.create(test_log)
-                
+
                 logger.error(f"Test execution failed: {error_message}")
-                
+
                 return TestExecutionResult(
                     log_id=saved_log.id,
                     status="failed",
+                    agent_id=agent.id,
+                    regression_test_id=request.regression_test_id,
                     llm_response=None,
                     response_time_ms=response_time_ms,
                     error_message=error_message,
-                    executed_at=saved_log.created_at
+                    executed_at=saved_log.created_at,
                 )
-                
+
         except ValueError as e:
             logger.error(f"Invalid test execution request: {e}")
             raise
@@ -179,18 +243,18 @@ class TestExecutionService:
         model_name: Optional[str] = None,
         system_prompt: Optional[str] = None,
         user_message: Optional[str] = None,
-        tools: Optional[list] = None
+        tools: Optional[list] = None,
     ) -> TestExecutionResult:
         """
         Execute a test case with optional parameter modifications.
-        
+
         Args:
             test_case_id: Test case ID to execute
             model_name: Override model name (optional)
             system_prompt: Override system prompt (optional)
             user_message: Override user message (optional)
             tools: Override tools (optional)
-            
+
         Returns:
             TestExecutionResult: Execution results
         """
@@ -198,23 +262,21 @@ class TestExecutionService:
             test_case_id=test_case_id,
             modified_system_prompt=system_prompt,
             modified_last_user_message=user_message,
-            modified_tools=tools
+            modified_tools=tools,
         )
-        
+
         return self.execute_test(request)
 
     def validate_execution_parameters(
-        self,
-        test_case_id: str,
-        model_name: Optional[str] = None
+        self, test_case_id: str, model_name: Optional[str] = None
     ) -> bool:
         """
         Validate that execution parameters are valid.
-        
+
         Args:
             test_case_id: Test case ID
             model_name: Model name to validate
-            
+
         Returns:
             bool: True if parameters are valid
         """
@@ -224,15 +286,15 @@ class TestExecutionService:
             if not test_case:
                 logger.debug(f"Test case not found: {test_case_id}")
                 return False
-            
+
             # Check if we have a valid model name
             effective_model_name = model_name or test_case.model_name
             if not effective_model_name or not effective_model_name.strip():
                 logger.debug("No valid model name available")
                 return False
-            
+
             return True
-            
+
         except Exception as e:
             logger.error(f"Error validating execution parameters: {e}")
             return False
@@ -240,10 +302,10 @@ class TestExecutionService:
     def get_execution_preview(self, test_case_id: str) -> dict:
         """
         Get a preview of what will be executed for a test case.
-        
+
         Args:
             test_case_id: Test case ID
-            
+
         Returns:
             Dict with execution preview data
         """
@@ -251,7 +313,7 @@ class TestExecutionService:
             test_case = self.test_case_service.get_test_case_for_execution(test_case_id)
             if not test_case:
                 return {"error": "Test case not found"}
-            
+
             return {
                 "test_case_id": test_case_id,
                 "test_case_name": test_case.name,
@@ -260,9 +322,9 @@ class TestExecutionService:
                 "user_message": test_case.last_user_message,
                 "has_tools": bool(test_case.tools),
                 "tools_count": len(test_case.tools) if test_case.tools else 0,
-                "other_messages_count": len(test_case.middle_messages)
+                "other_messages_count": len(test_case.middle_messages),
             }
-            
+
         except Exception as e:
             logger.error(f"Error getting execution preview: {e}")
             return {"error": str(e)}

--- a/src/services/test_execution_service.py
+++ b/src/services/test_execution_service.py
@@ -47,7 +47,7 @@ class TestExecutionData(BaseModel):
     )
 
 
-class TestExecutionResult(BaseModel):
+class ExecutionResult(BaseModel):
     """Service layer result of test execution."""
 
     status: str = Field(..., description="Execution status (success/failed)")
@@ -82,7 +82,7 @@ class TestExecutionService:
         self.test_log_store = TestLogStore()
         self.agent_service = AgentService()
 
-    async def execute_test(self, request: TestExecutionData) -> TestExecutionResult:
+    async def execute_test(self, request: TestExecutionData) -> ExecutionResult:
         """
         Execute a test case synchronously and record the results.
 
@@ -90,7 +90,7 @@ class TestExecutionService:
             request: Test execution request
 
         Returns:
-            TestExecutionResult: Execution results
+            ExecutionResult: Execution results
 
         Raises:
             ValueError: If test case not found or invalid parameters
@@ -181,7 +181,7 @@ class TestExecutionService:
 
                 logger.info(f"Test executed successfully: {saved_log.id}")
 
-                return TestExecutionResult(
+                return ExecutionResult(
                     log_id=saved_log.id,
                     status="success",
                     agent_id=agent.id,
@@ -219,7 +219,7 @@ class TestExecutionService:
 
                 logger.error(f"Test execution failed: {error_message}")
 
-                return TestExecutionResult(
+                return ExecutionResult(
                     log_id=saved_log.id,
                     status="failed",
                     agent_id=agent.id,
@@ -244,7 +244,7 @@ class TestExecutionService:
         system_prompt: Optional[str] = None,
         user_message: Optional[str] = None,
         tools: Optional[list] = None,
-    ) -> TestExecutionResult:
+    ) -> ExecutionResult:
         """
         Execute a test case with optional parameter modifications.
 
@@ -256,7 +256,7 @@ class TestExecutionService:
             tools: Override tools (optional)
 
         Returns:
-            TestExecutionResult: Execution results
+            ExecutionResult: Execution results
         """
         request = TestExecutionData(
             test_case_id=test_case_id,

--- a/src/services/test_log_service.py
+++ b/src/services/test_log_service.py
@@ -6,6 +6,7 @@ Service for viewing and filtering test execution logs.
 
 from datetime import datetime
 from typing import Dict, List, Optional
+
 from pydantic import BaseModel, Field
 
 from src.core.logger import get_logger
@@ -13,26 +14,37 @@ from src.stores.test_log_store import TestLogStore
 
 logger = get_logger(__name__)
 
+
 class TestLogData(BaseModel):
     """Service layer representation of a test log."""
 
     id: str = Field(..., description="Test log ID")
     test_case_id: str = Field(..., description="Associated test case ID")
+    agent_id: str = Field(..., description="Associated agent ID")
+    regression_test_id: Optional[str] = Field(
+        None, description="Regression test that produced the log"
+    )
     model_name: str = Field(..., description="Model used for execution")
-    model_settings: Optional[Dict] = Field(None, description="Model settings JSON used for execution")
+    model_settings: Optional[Dict] = Field(
+        None, description="Model settings JSON used for execution"
+    )
     system_prompt: str = Field(..., description="System prompt used")
     user_message: str = Field(..., description="User message used")
     tools: Optional[List[Dict]] = Field(None, description="Tools configuration used")
     llm_response: Optional[str] = Field(None, description="LLM response text")
-    response_time_ms: Optional[int] = Field(None, description="Response time in milliseconds")
+    response_time_ms: Optional[int] = Field(
+        None, description="Response time in milliseconds"
+    )
     status: str = Field(..., description="Execution status")
     error_message: Optional[str] = Field(None, description="Error message if failed")
     created_at: datetime = Field(..., description="Creation timestamp")
-    
+
     # Additional service-layer specific fields
     execution_metadata: Optional[Dict] = Field(None, description="Execution metadata")
-    performance_data: Optional[Dict] = Field(None, description="Performance analysis data")
-    
+    performance_data: Optional[Dict] = Field(
+        None, description="Performance analysis data"
+    )
+
     class Config:
         from_attributes = True
 
@@ -46,10 +58,10 @@ class TestLogService:
     def get_test_log(self, log_id: str) -> Optional[TestLogData]:
         """
         Get a test log by ID.
-        
+
         Args:
             log_id: Test log ID
-            
+
         Returns:
             TestLogData or None if not found
         """
@@ -58,10 +70,12 @@ class TestLogService:
             if not test_log:
                 logger.debug(f"Test log not found: {log_id}")
                 return None
-            
+
             return TestLogData(
                 id=test_log.id,
                 test_case_id=test_log.test_case_id,
+                agent_id=test_log.agent_id,
+                regression_test_id=test_log.regression_test_id,
                 model_name=test_log.model_name,
                 model_settings=test_log.model_settings,
                 system_prompt=test_log.system_prompt,
@@ -71,41 +85,38 @@ class TestLogService:
                 response_time_ms=test_log.response_time_ms,
                 status=test_log.status,
                 error_message=test_log.error_message,
-                created_at=test_log.created_at
+                created_at=test_log.created_at,
             )
-            
+
         except Exception as e:
             logger.error(f"Failed to get test log {log_id}: {e}")
             raise
 
     def get_logs_by_test_case(
-        self, 
-        test_case_id: str, 
-        limit: int = 100, 
-        offset: int = 0
+        self, test_case_id: str, limit: int = 100, offset: int = 0
     ) -> List[TestLogData]:
         """
         Get test logs for a specific test case.
-        
+
         Args:
             test_case_id: Test case ID to filter by
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of test log responses
         """
         try:
             test_logs = self.store.get_by_test_case_id(
-                test_case_id=test_case_id,
-                limit=limit,
-                offset=offset
+                test_case_id=test_case_id, limit=limit, offset=offset
             )
-            
+
             return [
                 TestLogData(
                     id=log.id,
                     test_case_id=log.test_case_id,
+                    agent_id=log.agent_id,
+                    regression_test_id=log.regression_test_id,
                     model_name=log.model_name,
                     model_settings=log.model_settings,
                     system_prompt=log.system_prompt,
@@ -115,33 +126,76 @@ class TestLogService:
                     response_time_ms=log.response_time_ms,
                     status=log.status,
                     error_message=log.error_message,
-                    created_at=log.created_at
+                    created_at=log.created_at,
                 )
                 for log in test_logs
             ]
-            
+
         except Exception as e:
             logger.error(f"Failed to get logs for test case {test_case_id}: {e}")
+            raise
+
+    def get_logs_by_regression_test(
+        self,
+        regression_test_id: str,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[TestLogData]:
+        """Return logs produced by a specific regression test."""
+
+        try:
+            test_logs = self.store.get_by_regression_test(
+                regression_test_id=regression_test_id,
+                limit=limit,
+                offset=offset,
+            )
+
+            return [
+                TestLogData(
+                    id=log.id,
+                    test_case_id=log.test_case_id,
+                    agent_id=log.agent_id,
+                    regression_test_id=log.regression_test_id,
+                    model_name=log.model_name,
+                    model_settings=log.model_settings,
+                    system_prompt=log.system_prompt,
+                    user_message=log.user_message,
+                    tools=log.tools,
+                    llm_response=log.llm_response,
+                    response_time_ms=log.response_time_ms,
+                    status=log.status,
+                    error_message=log.error_message,
+                    created_at=log.created_at,
+                )
+                for log in test_logs
+            ]
+
+        except Exception as e:
+            logger.error(
+                f"Failed to get logs for regression test {regression_test_id}: {e}"
+            )
             raise
 
     def get_all_logs(self, limit: int = 100, offset: int = 0) -> List[TestLogData]:
         """
         Get all test logs with pagination.
-        
+
         Args:
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of test log responses
         """
         try:
             test_logs = self.store.get_all(limit=limit, offset=offset)
-            
+
             return [
                 TestLogData(
                     id=log.id,
                     test_case_id=log.test_case_id,
+                    agent_id=log.agent_id,
+                    regression_test_id=log.regression_test_id,
                     model_name=log.model_name,
                     model_settings=log.model_settings,
                     system_prompt=log.system_prompt,
@@ -151,29 +205,31 @@ class TestLogService:
                     response_time_ms=log.response_time_ms,
                     status=log.status,
                     error_message=log.error_message,
-                    created_at=log.created_at
+                    created_at=log.created_at,
                 )
                 for log in test_logs
             ]
-            
+
         except Exception as e:
             logger.error(f"Failed to get all test logs: {e}")
             raise
 
     def get_logs_by_status(
-        self, 
-        status: str, 
-        limit: int = 100, 
-        offset: int = 0
+        self,
+        status: str,
+        limit: int = 100,
+        offset: int = 0,
+        agent_id: Optional[str] = None,
+        regression_test_id: Optional[str] = None,
     ) -> List[TestLogData]:
         """
         Get test logs filtered by status.
-        
+
         Args:
             status: Status to filter by (success, failed)
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of test log responses with the specified status
         """
@@ -181,13 +237,17 @@ class TestLogService:
             test_logs = self.store.get_by_status(
                 status=status,
                 limit=limit,
-                offset=offset
+                offset=offset,
+                agent_id=agent_id,
+                regression_test_id=regression_test_id,
             )
-            
+
             return [
                 TestLogData(
                     id=log.id,
                     test_case_id=log.test_case_id,
+                    agent_id=log.agent_id,
+                    regression_test_id=log.regression_test_id,
                     model_name=log.model_name,
                     model_settings=log.model_settings,
                     system_prompt=log.system_prompt,
@@ -197,11 +257,11 @@ class TestLogService:
                     response_time_ms=log.response_time_ms,
                     status=log.status,
                     error_message=log.error_message,
-                    created_at=log.created_at
+                    created_at=log.created_at,
                 )
                 for log in test_logs
             ]
-            
+
         except Exception as e:
             logger.error(f"Failed to get logs by status {status}: {e}")
             raise
@@ -209,11 +269,11 @@ class TestLogService:
     def get_success_logs(self, limit: int = 100, offset: int = 0) -> List[TestLogData]:
         """
         Get successful test logs.
-        
+
         Args:
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of successful test log responses
         """
@@ -236,8 +296,10 @@ class TestLogService:
         self,
         status: Optional[str] = None,
         test_case_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        regression_test_id: Optional[str] = None,
         limit: int = 100,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[TestLogData]:
         """
         Get test logs with combined filters.
@@ -255,14 +317,18 @@ class TestLogService:
             test_logs = self.store.get_filtered(
                 status=status,
                 test_case_id=test_case_id,
+                agent_id=agent_id,
+                regression_test_id=regression_test_id,
                 limit=limit,
-                offset=offset
+                offset=offset,
             )
 
             return [
                 TestLogData(
                     id=log.id,
                     test_case_id=log.test_case_id,
+                    agent_id=log.agent_id,
+                    regression_test_id=log.regression_test_id,
                     model_name=log.model_name,
                     model_settings=log.model_settings,
                     system_prompt=log.system_prompt,
@@ -272,8 +338,9 @@ class TestLogService:
                     response_time_ms=log.response_time_ms,
                     status=log.status,
                     error_message=log.error_message,
-                    created_at=log.created_at
-                ) for log in test_logs
+                    created_at=log.created_at,
+                )
+                for log in test_logs
             ]
 
         except Exception as e:
@@ -283,10 +350,10 @@ class TestLogService:
     def delete_test_log(self, log_id: str) -> bool:
         """
         Delete a test log by ID.
-        
+
         Args:
             log_id: Test log ID to delete
-            
+
         Returns:
             bool: True if deleted, False if not found
         """
@@ -297,7 +364,7 @@ class TestLogService:
             else:
                 logger.debug(f"Test log not found for deletion: {log_id}")
             return deleted
-            
+
         except Exception as e:
             logger.error(f"Failed to delete test log {log_id}: {e}")
             raise
@@ -305,10 +372,10 @@ class TestLogService:
     def delete_logs_by_test_case(self, test_case_id: str) -> int:
         """
         Delete all test logs for a test case.
-        
+
         Args:
             test_case_id: Test case ID
-            
+
         Returns:
             int: Number of deleted test logs
         """
@@ -316,7 +383,7 @@ class TestLogService:
             deleted_count = self.store.delete_by_test_case_id(test_case_id)
             logger.info(f"Deleted {deleted_count} test logs for case {test_case_id}")
             return deleted_count
-            
+
         except Exception as e:
             logger.error(f"Failed to delete logs for test case {test_case_id}: {e}")
             raise
@@ -324,7 +391,7 @@ class TestLogService:
     def get_log_statistics(self) -> dict:
         """
         Get statistics about test logs.
-        
+
         Returns:
             Dict with log statistics
         """
@@ -333,23 +400,23 @@ class TestLogService:
             success_logs = self.store.get_by_status("success", limit=1)
             failed_logs = self.store.get_by_status("failed", limit=1)
             all_logs = self.store.get_all(limit=1)
-            
+
             # For a more accurate count, we'd need to implement count methods
             # For now, we'll use the length of limited results as approximation
             return {
                 "total_logs": len(all_logs),  # This is not accurate for large datasets
                 "success_count": len(success_logs),  # This is not accurate
                 "failed_count": len(failed_logs),  # This is not accurate
-                "success_rate": 0.0  # Would need proper counts to calculate
+                "success_rate": 0.0,  # Would need proper counts to calculate
             }
-            
+
         except Exception as e:
             logger.error(f"Failed to get log statistics: {e}")
             return {
                 "total_logs": 0,
                 "success_count": 0,
                 "failed_count": 0,
-                "success_rate": 0.0
+                "success_rate": 0.0,
             }
 
 

--- a/src/services/test_log_service.py
+++ b/src/services/test_log_service.py
@@ -7,7 +7,7 @@ Service for viewing and filtering test execution logs.
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.core.logger import get_logger
 from src.stores.test_log_store import TestLogStore
@@ -45,8 +45,7 @@ class TestLogData(BaseModel):
         None, description="Performance analysis data"
     )
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class TestLogService:

--- a/src/stores/agent_store.py
+++ b/src/stores/agent_store.py
@@ -65,7 +65,7 @@ class AgentStore:
                 query = db.query(Agent)
                 if not include_deleted:
                     query = query.filter(Agent.is_deleted.is_(False))
-                return query.order_by(Agent.created_at.asc()).all()
+                return query.order_by(Agent.created_at.desc()).all()
         except Exception as exc:  # pragma: no cover
             logger.error("Failed to list agents: %s", exc)
             raise DatabaseException(

--- a/src/stores/agent_store.py
+++ b/src/stores/agent_store.py
@@ -1,0 +1,130 @@
+"""Agent data access layer."""
+
+from typing import List, Optional
+
+from src.core.error_codes import DatabaseErrorCode
+from src.core.exceptions import DatabaseException
+from src.core.logger import get_logger
+from src.models import Agent
+from src.stores.database import database_session
+
+logger = get_logger(__name__)
+
+
+class AgentStore:
+    """Store class encapsulating CRUD operations for agents."""
+
+    def create(self, agent: Agent) -> Agent:
+        try:
+            with database_session() as db:
+                db.add(agent)
+                db.commit()
+                db.refresh(agent)
+                logger.info("Created agent %s", agent.id)
+                return agent
+        except Exception as exc:  # pragma: no cover - wrapped for consistency
+            logger.error("Failed to create agent: %s", exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to create agent: {exc}",
+            ) from exc
+
+    def get_by_id(
+        self, agent_id: str, include_deleted: bool = False
+    ) -> Optional[Agent]:
+        try:
+            with database_session() as db:
+                query = db.query(Agent).filter(Agent.id == agent_id)
+                if not include_deleted:
+                    query = query.filter(Agent.is_deleted.is_(False))
+                return query.first()
+        except Exception as exc:  # pragma: no cover - consistent handling
+            logger.error("Failed to fetch agent %s: %s", agent_id, exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to fetch agent: {exc}",
+            ) from exc
+
+    def get_by_name(self, name: str, include_deleted: bool = False) -> Optional[Agent]:
+        try:
+            with database_session() as db:
+                query = db.query(Agent).filter(Agent.name == name)
+                if not include_deleted:
+                    query = query.filter(Agent.is_deleted.is_(False))
+                return query.first()
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed to fetch agent by name %s: %s", name, exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to fetch agent: {exc}",
+            ) from exc
+
+    def list_agents(self, include_deleted: bool = False) -> List[Agent]:
+        try:
+            with database_session() as db:
+                query = db.query(Agent)
+                if not include_deleted:
+                    query = query.filter(Agent.is_deleted.is_(False))
+                return query.order_by(Agent.created_at.asc()).all()
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed to list agents: %s", exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to list agents: {exc}",
+            ) from exc
+
+    def update(self, agent: Agent) -> Agent:
+        try:
+            with database_session() as db:
+                merged = db.merge(agent)
+                db.commit()
+                db.refresh(merged)
+                logger.info("Updated agent %s", merged.id)
+                return merged
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed to update agent %s: %s", agent.id, exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to update agent: {exc}",
+            ) from exc
+
+    def soft_delete(self, agent_id: str) -> bool:
+        try:
+            with database_session() as db:
+                agent = db.query(Agent).filter(Agent.id == agent_id).first()
+                if not agent:
+                    return False
+                if agent.is_deleted:
+                    return True
+                agent.is_deleted = True
+                db.commit()
+                logger.info("Soft deleted agent %s", agent_id)
+                return True
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed to soft delete agent %s: %s", agent_id, exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to delete agent: {exc}",
+            ) from exc
+
+    def restore(self, agent_id: str) -> bool:
+        try:
+            with database_session() as db:
+                agent = db.query(Agent).filter(Agent.id == agent_id).first()
+                if not agent:
+                    return False
+                if not agent.is_deleted:
+                    return True
+                agent.is_deleted = False
+                db.commit()
+                logger.info("Restored agent %s", agent_id)
+                return True
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed to restore agent %s: %s", agent_id, exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to restore agent: {exc}",
+            ) from exc
+
+
+__all__ = ["AgentStore"]

--- a/src/stores/regression_test_store.py
+++ b/src/stores/regression_test_store.py
@@ -1,0 +1,97 @@
+"""Regression test persistence layer."""
+
+from typing import List, Optional
+
+from sqlalchemy import desc
+
+from src.core.error_codes import DatabaseErrorCode
+from src.core.exceptions import DatabaseException
+from src.core.logger import get_logger
+from src.models import RegressionTest
+from src.stores.database import database_session
+
+logger = get_logger(__name__)
+
+
+class RegressionTestStore:
+    """Store class for regression test records."""
+
+    def create(self, regression_test: RegressionTest) -> RegressionTest:
+        try:
+            with database_session() as db:
+                db.add(regression_test)
+                db.commit()
+                db.refresh(regression_test)
+                logger.info("Created regression test %s", regression_test.id)
+                return regression_test
+        except Exception as exc:  # pragma: no cover - consistent error handling
+            logger.error("Failed to create regression test: %s", exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to create regression test: {exc}",
+            ) from exc
+
+    def update(self, regression_test: RegressionTest) -> RegressionTest:
+        try:
+            with database_session() as db:
+                merged = db.merge(regression_test)
+                db.commit()
+                db.refresh(merged)
+                logger.info("Updated regression test %s", merged.id)
+                return merged
+        except Exception as exc:  # pragma: no cover
+            logger.error(
+                "Failed to update regression test %s: %s", regression_test.id, exc
+            )
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to update regression test: {exc}",
+            ) from exc
+
+    def get_by_id(self, regression_test_id: str) -> Optional[RegressionTest]:
+        try:
+            with database_session() as db:
+                return (
+                    db.query(RegressionTest)
+                    .filter(RegressionTest.id == regression_test_id)
+                    .first()
+                )
+        except Exception as exc:  # pragma: no cover
+            logger.error(
+                "Failed to fetch regression test %s: %s", regression_test_id, exc
+            )
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to fetch regression test: {exc}",
+            ) from exc
+
+    def list_regression_tests(
+        self,
+        *,
+        agent_id: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[RegressionTest]:
+        try:
+            with database_session() as db:
+                query = db.query(RegressionTest)
+                if agent_id:
+                    query = query.filter(RegressionTest.agent_id == agent_id)
+                if status:
+                    query = query.filter(RegressionTest.status == status)
+                return (
+                    query.order_by(desc(RegressionTest.created_at))
+                    .limit(limit)
+                    .offset(offset)
+                    .all()
+                )
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed to list regression tests: %s", exc)
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to list regression tests: {exc}",
+            ) from exc
+
+
+__all__ = ["RegressionTestStore"]

--- a/src/stores/regression_test_store.py
+++ b/src/stores/regression_test_store.py
@@ -108,7 +108,9 @@ class RegressionTestStore:
                     db.query(RegressionTest)
                     .filter(RegressionTest.agent_id == agent_id)
                     .filter(RegressionTest.is_deleted.is_(False))
-                    .update({RegressionTest.is_deleted: True}, synchronize_session=False)
+                    .update(
+                        {RegressionTest.is_deleted: True}, synchronize_session=False
+                    )
                 )
                 db.commit()
                 logger.info(

--- a/src/stores/test_log_store.py
+++ b/src/stores/test_log_store.py
@@ -28,13 +28,13 @@ class TestLogStore:
     def create(self, test_log: TestLog) -> TestLog:
         """
         Create a new test log.
-        
+
         Args:
             test_log: TestLog instance to create
-            
+
         Returns:
             TestLog: Created test log
-            
+
         Raises:
             DatabaseException: If creation fails
         """
@@ -43,26 +43,25 @@ class TestLogStore:
                 db.add(test_log)
                 db.commit()
                 db.refresh(test_log)
-                logger.info(f"Created test log: {test_log.id}")
+                logger.info("Created test log: %s", test_log.id)
                 return test_log
-                
+
         except Exception as e:
             logger.error(f"Failed to create test log: {e}")
             raise DatabaseException(
-                DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to create test log: {str(e)}"
+                DatabaseErrorCode.QUERY_FAILED, f"Failed to create test log: {str(e)}"
             ) from e
 
     def get_by_id(self, test_log_id: str) -> Optional[TestLog]:
         """
         Get test log by ID.
-        
+
         Args:
             test_log_id: Test log ID
-            
+
         Returns:
             TestLog or None if not found
-            
+
         Raises:
             DatabaseException: If query fails
         """
@@ -70,35 +69,31 @@ class TestLogStore:
             with database_session() as db:
                 test_log = db.query(TestLog).filter(TestLog.id == test_log_id).first()
                 if test_log:
-                    logger.debug(f"Found test log: {test_log_id}")
+                    logger.debug("Found test log: %s", test_log_id)
                 else:
-                    logger.debug(f"Test log not found: {test_log_id}")
+                    logger.debug("Test log not found: %s", test_log_id)
                 return test_log
-                
+
         except Exception as e:
             logger.error(f"Failed to get test log {test_log_id}: {e}")
             raise DatabaseException(
-                DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to get test log: {str(e)}"
+                DatabaseErrorCode.QUERY_FAILED, f"Failed to get test log: {str(e)}"
             ) from e
 
     def get_by_test_case_id(
-        self, 
-        test_case_id: str, 
-        limit: int = 100, 
-        offset: int = 0
+        self, test_case_id: str, limit: int = 100, offset: int = 0
     ) -> List[TestLog]:
         """
         Get test logs by test case ID with pagination.
-        
+
         Args:
             test_case_id: Test case ID to filter by
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of test logs for the test case
-            
+
         Raises:
             DatabaseException: If query fails
         """
@@ -112,14 +107,15 @@ class TestLogStore:
                     .offset(offset)
                     .all()
                 )
-                logger.debug(f"Retrieved {len(test_logs)} test logs for case {test_case_id}")
+                logger.debug(
+                    "Retrieved %s test logs for case %s", len(test_logs), test_case_id
+                )
                 return test_logs
-                
+
         except Exception as e:
             logger.error(f"Failed to get test logs for case {test_case_id}: {e}")
             raise DatabaseException(
-                DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to get test logs: {str(e)}"
+                DatabaseErrorCode.QUERY_FAILED, f"Failed to get test logs: {str(e)}"
             ) from e
 
     def _query_with_active_test_cases(self, db: Session):
@@ -134,14 +130,14 @@ class TestLogStore:
     def get_all(self, limit: int = 100, offset: int = 0) -> List[TestLog]:
         """
         Get all test logs with pagination.
-        
+
         Args:
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of test logs
-            
+
         Raises:
             DatabaseException: If query fails
         """
@@ -156,60 +152,71 @@ class TestLogStore:
                 )
                 logger.debug(f"Retrieved {len(test_logs)} test logs")
                 return test_logs
-                
+
         except Exception as e:
             logger.error(f"Failed to get test logs: {e}")
             raise DatabaseException(
-                DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to get test logs: {str(e)}"
+                DatabaseErrorCode.QUERY_FAILED, f"Failed to get test logs: {str(e)}"
             ) from e
 
     def get_by_status(
-        self, 
-        status: str, 
-        limit: int = 100, 
-        offset: int = 0
+        self,
+        status: str,
+        limit: int = 100,
+        offset: int = 0,
+        agent_id: Optional[str] = None,
+        regression_test_id: Optional[str] = None,
     ) -> List[TestLog]:
         """
         Get test logs by status with pagination.
-        
+
         Args:
             status: Status to filter by (success, failed)
             limit: Maximum number of results
             offset: Number of results to skip
-            
+
         Returns:
             List of test logs with the specified status
-            
+
         Raises:
             DatabaseException: If query fails
         """
         try:
             with database_session() as db:
                 query = self._query_with_active_test_cases(db)
+                query = query.filter(TestLog.status == status)
+                if agent_id:
+                    query = query.filter(TestLog.agent_id == agent_id)
+                if regression_test_id:
+                    query = query.filter(
+                        TestLog.regression_test_id == regression_test_id
+                    )
                 test_logs = (
-                    query.filter(TestLog.status == status)
-                    .order_by(desc(TestLog.created_at))
+                    query.order_by(desc(TestLog.created_at))
                     .limit(limit)
                     .offset(offset)
                     .all()
                 )
-                logger.debug(f"Retrieved {len(test_logs)} test logs with status {status}")
+                logger.debug(
+                    "Retrieved %s test logs with status %s", len(test_logs), status
+                )
                 return test_logs
-                
+
         except Exception as e:
             logger.error(f"Failed to get test logs by status {status}: {e}")
             raise DatabaseException(
                 DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to get test logs by status: {str(e)}"
+                f"Failed to get test logs by status: {str(e)}",
             ) from e
 
     def get_filtered(
         self,
         status: Optional[str] = None,
         test_case_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        regression_test_id: Optional[str] = None,
         limit: int = 100,
-        offset: int = 0
+        offset: int = 0,
     ) -> List[TestLog]:
         """
         Get test logs with combined filters.
@@ -235,6 +242,12 @@ class TestLogStore:
                     query = query.filter(TestLog.status == status)
                 if test_case_id:
                     query = query.filter(TestLog.test_case_id == test_case_id)
+                if agent_id:
+                    query = query.filter(TestLog.agent_id == agent_id)
+                if regression_test_id:
+                    query = query.filter(
+                        TestLog.regression_test_id == regression_test_id
+                    )
 
                 test_logs = (
                     query.order_by(desc(TestLog.created_at))
@@ -242,26 +255,59 @@ class TestLogStore:
                     .offset(offset)
                     .all()
                 )
-                logger.debug(f"Retrieved {len(test_logs)} filtered test logs")
+                logger.debug("Retrieved %s filtered test logs", len(test_logs))
                 return test_logs
 
         except Exception as e:
             logger.error(f"Failed to get filtered test logs: {e}")
             raise DatabaseException(
                 DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to get filtered test logs: {str(e)}"
+                f"Failed to get filtered test logs: {str(e)}",
+            ) from e
+
+    def get_by_regression_test(
+        self,
+        regression_test_id: str,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[TestLog]:
+        """Return logs that belong to a specific regression test."""
+
+        try:
+            with database_session() as db:
+                query = self._query_with_active_test_cases(db)
+                test_logs = (
+                    query.filter(TestLog.regression_test_id == regression_test_id)
+                    .order_by(desc(TestLog.created_at))
+                    .limit(limit)
+                    .offset(offset)
+                    .all()
+                )
+                logger.debug(
+                    "Retrieved %s logs for regression test %s",
+                    len(test_logs),
+                    regression_test_id,
+                )
+                return test_logs
+        except Exception as e:  # pragma: no cover
+            logger.error(
+                "Failed to get logs for regression test %s: %s", regression_test_id, e
+            )
+            raise DatabaseException(
+                DatabaseErrorCode.QUERY_FAILED,
+                f"Failed to get regression test logs: {str(e)}",
             ) from e
 
     def delete(self, test_log_id: str) -> bool:
         """
         Delete a test log by ID.
-        
+
         Args:
             test_log_id: Test log ID to delete
-            
+
         Returns:
             bool: True if deleted, False if not found
-            
+
         Raises:
             DatabaseException: If deletion fails
         """
@@ -271,29 +317,28 @@ class TestLogStore:
                 if test_log:
                     db.delete(test_log)
                     db.commit()
-                    logger.info(f"Deleted test log: {test_log_id}")
+                    logger.info("Deleted test log: %s", test_log_id)
                     return True
                 else:
-                    logger.debug(f"Test log not found for deletion: {test_log_id}")
+                    logger.debug("Test log not found for deletion: %s", test_log_id)
                     return False
-                    
+
         except Exception as e:
             logger.error(f"Failed to delete test log {test_log_id}: {e}")
             raise DatabaseException(
-                DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to delete test log: {str(e)}"
+                DatabaseErrorCode.QUERY_FAILED, f"Failed to delete test log: {str(e)}"
             ) from e
 
     def delete_by_test_case_id(self, test_case_id: str) -> int:
         """
         Delete all test logs for a test case.
-        
+
         Args:
             test_case_id: Test case ID
-            
+
         Returns:
             int: Number of deleted test logs
-            
+
         Raises:
             DatabaseException: If deletion fails
         """
@@ -305,14 +350,15 @@ class TestLogStore:
                     .delete()
                 )
                 db.commit()
-                logger.info(f"Deleted {deleted_count} test logs for case {test_case_id}")
+                logger.info(
+                    "Deleted %s test logs for case %s", deleted_count, test_case_id
+                )
                 return deleted_count
-                
+
         except Exception as e:
             logger.error(f"Failed to delete test logs for case {test_case_id}: {e}")
             raise DatabaseException(
-                DatabaseErrorCode.QUERY_FAILED,
-                f"Failed to delete test logs: {str(e)}"
+                DatabaseErrorCode.QUERY_FAILED, f"Failed to delete test logs: {str(e)}"
             ) from e
 
 

--- a/src/stores/test_log_store.py
+++ b/src/stores/test_log_store.py
@@ -5,7 +5,7 @@ Data access layer for test log operations.
 The list-style queries in this store deliberately exclude logs that belong to
 soft-deleted test cases so that UI listings stay in sync with the visible test
 case catalog. Individual log lookups remain unrestricted and can still access
-records tied to archived test cases.
+records tied to deleted test cases.
 """
 
 from typing import List, Optional

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -76,3 +76,24 @@ body {
     background-color: rgba(37, 99, 235, 0.1);
     font-weight: 600;
 }
+
+#toast-root {
+    position: fixed;
+    top: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1100;
+    width: min(90vw, 420px);
+    pointer-events: none;
+}
+
+#toast-root .alert {
+    pointer-events: auto;
+    box-shadow: 0 18px 35px -15px rgba(15, 23, 42, 0.45);
+    border: none;
+    border-radius: 0.75rem;
+}
+
+#toast-root .alert + .alert {
+    margin-top: 0.75rem;
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,0 +1,78 @@
+:root {
+    --primary-color: #2563eb;
+    --primary-hover: #1d4ed8;
+    --secondary-color: #64748b;
+    --success-color: #059669;
+    --warning-color: #d97706;
+    --danger-color: #dc2626;
+    --background-color: #f8fafc;
+    --card-background: #ffffff;
+    --border-color: #e2e8f0;
+    --text-primary: #1e293b;
+    --text-secondary: #64748b;
+    --text-muted: #94a3b8;
+}
+
+body {
+    background-color: var(--background-color);
+    color: var(--text-primary);
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.navbar {
+    background: var(--card-background) !important;
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+    padding: 1rem 0;
+}
+
+.navbar-brand {
+    font-weight: 700;
+    color: var(--text-primary) !important;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.navbar-brand i {
+    color: var(--primary-color);
+    font-size: 1.5rem;
+}
+
+.brand-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.brand-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.brand-subtitle {
+    font-size: 0.75rem;
+    font-weight: 400;
+    color: var(--text-muted) !important;
+    line-height: 1.1;
+}
+
+.navbar-nav .nav-link {
+    font-weight: 500;
+    color: var(--text-secondary) !important;
+    padding: 0.5rem 1rem !important;
+    border-radius: 0.375rem;
+    transition: all 0.2s ease;
+}
+
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus {
+    color: var(--primary-color) !important;
+    background-color: rgba(37, 99, 235, 0.1);
+}
+
+.navbar-nav .nav-link.active {
+    color: var(--primary-color) !important;
+    background-color: rgba(37, 99, 235, 0.1);
+    font-weight: 600;
+}

--- a/static/js/agents.js
+++ b/static/js/agents.js
@@ -1,0 +1,458 @@
+/**
+ * Agents Management JavaScript
+ *
+ * Handles fetching, creating, updating, and archiving agents for the replay UI.
+ */
+
+let agents = [];
+let includeDeleted = false;
+
+// Initialize page
+window.addEventListener('DOMContentLoaded', () => {
+    setupEventListeners();
+    loadAgents();
+});
+
+function setupEventListeners() {
+    const toggle = document.getElementById('includeDeletedToggle');
+    if (toggle) {
+        toggle.addEventListener('change', () => {
+            includeDeleted = toggle.checked;
+            loadAgents();
+        });
+    }
+
+    const refreshBtn = document.getElementById('refreshAgentsBtn');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', () => loadAgents());
+    }
+
+    const createBtn = document.getElementById('confirmCreateAgent');
+    if (createBtn) {
+        createBtn.addEventListener('click', createAgent);
+    }
+
+    const updateBtn = document.getElementById('confirmUpdateAgent');
+    if (updateBtn) {
+        updateBtn.addEventListener('click', updateAgent);
+    }
+
+    const createModal = document.getElementById('createAgentModal');
+    if (createModal) {
+        createModal.addEventListener('hidden.bs.modal', () => {
+            document.getElementById('createAgentForm').reset();
+            clearModalAlert('createAgentAlert');
+        });
+    }
+
+    const editModal = document.getElementById('editAgentModal');
+    if (editModal) {
+        editModal.addEventListener('hidden.bs.modal', () => {
+            clearModalAlert('editAgentAlert');
+        });
+    }
+}
+
+async function loadAgents() {
+    toggleLoading(true);
+    try {
+        const url = new URL('/v1/api/agents/', window.location.origin);
+        if (includeDeleted) {
+            url.searchParams.append('include_deleted', 'true');
+        }
+
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        agents = await response.json();
+        displayAgents(agents);
+        updateAgentHints(agents);
+    } catch (error) {
+        console.error('Error loading agents:', error);
+        showAlert('Error loading agents: ' + error.message, 'danger');
+    } finally {
+        toggleLoading(false);
+    }
+}
+
+function displayAgents(agentList) {
+    const container = document.getElementById('agentsList');
+    const table = document.getElementById('agentsTable');
+    const emptyState = document.getElementById('emptyState');
+
+    if (!container || !table || !emptyState) {
+        return;
+    }
+
+    if (!agentList || agentList.length === 0) {
+        container.innerHTML = '';
+        table.style.display = 'none';
+        emptyState.classList.remove('d-none');
+        return;
+    }
+
+    table.style.display = 'table';
+    emptyState.classList.add('d-none');
+
+    const rows = agentList
+        .map((agent) => {
+            const statusBadge = agent.is_deleted
+                ? '<span class="badge bg-secondary">Archived</span>'
+                : '<span class="badge bg-success">Active</span>';
+            const description = agent.description
+                ? `<small class="text-muted">${escapeHtml(truncateText(agent.description, 80))}</small>`
+                : '';
+            const systemPrompt = agent.default_system_prompt
+                ? `<div class="text-truncate" style="max-width: 260px;" title="${escapeHtml(agent.default_system_prompt)}">${escapeHtml(truncateText(agent.default_system_prompt, 120))}</div>`
+                : '<span class="text-muted">—</span>';
+            const modelSettings = agent.default_model_settings
+                ? `<code class="text-muted">${escapeHtml(truncateText(JSON.stringify(agent.default_model_settings), 120))}</code>`
+                : '<span class="text-muted">Inherited per case</span>';
+
+            const updatedAt = formatDate(agent.updated_at);
+
+            return `
+            <tr>
+                <td>
+                    <div class="d-flex flex-column">
+                        <div class="d-flex align-items-center gap-2">
+                            <strong>${escapeHtml(agent.name)}</strong>
+                            ${agent.is_deleted ? '<span class="badge bg-secondary">Archived</span>' : ''}
+                        </div>
+                        ${description}
+                    </div>
+                </td>
+                <td>
+                    <div class="d-flex flex-column gap-1">
+                        <span class="badge bg-primary">${escapeHtml(agent.default_model_name || 'Not set')}</span>
+                        ${systemPrompt}
+                        <div class="text-muted small">${modelSettings}</div>
+                    </div>
+                </td>
+                <td>
+                    <div class="d-flex flex-column">
+                        <span>${updatedAt}</span>
+                        <small class="text-muted">Created ${formatDate(agent.created_at)}</small>
+                    </div>
+                </td>
+                <td>${statusBadge}</td>
+                <td class="text-end">
+                    <div class="btn-group btn-group-sm" role="group">
+                        <button type="button" class="btn btn-outline-primary" onclick="openEditAgent('${agent.id}')">
+                            <i class="fas fa-edit"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" onclick="openAgentTestCases('${agent.id}')" title="View test cases">
+                            <i class="fas fa-list"></i>
+                        </button>
+                        ${agent.is_deleted
+                            ? `<button type="button" class="btn btn-outline-success" onclick="restoreAgent('${agent.id}')"><i class="fas fa-undo"></i></button>`
+                            : `<button type="button" class="btn btn-outline-danger" onclick="archiveAgent('${agent.id}')"><i class="fas fa-archive"></i></button>`
+                        }
+                    </div>
+                </td>
+            </tr>`;
+        })
+        .join('');
+
+    container.innerHTML = rows;
+}
+
+function updateAgentHints(agentList) {
+    const hint = document.getElementById('agentHelp');
+    if (!hint) {
+        return;
+    }
+
+    const activeAgents = agentList.filter((agent) => !agent.is_deleted);
+    if (activeAgents.length === 0) {
+        hint.classList.remove('d-none');
+    } else {
+        hint.classList.add('d-none');
+    }
+}
+
+async function createAgent() {
+    const nameInput = document.getElementById('createAgentName');
+    const descriptionInput = document.getElementById('createAgentDescription');
+    const modelNameInput = document.getElementById('createAgentModelName');
+    const systemPromptInput = document.getElementById('createAgentSystemPrompt');
+    const modelSettingsInput = document.getElementById('createAgentModelSettings');
+
+    const name = nameInput.value.trim();
+    const modelName = modelNameInput.value.trim();
+    const systemPrompt = systemPromptInput.value.trim();
+
+    if (!name || !modelName || !systemPrompt) {
+        showModalAlert('createAgentAlert', 'Name, default model, and system prompt are required.', 'warning');
+        return;
+    }
+
+    let modelSettings = {};
+    try {
+        modelSettings = parseJsonOrThrow(modelSettingsInput.value.trim(), {});
+    } catch (error) {
+        showModalAlert('createAgentAlert', error.message, 'danger');
+        return;
+    }
+
+    const payload = {
+        name: name,
+        description: descriptionInput.value.trim() || null,
+        default_model_name: modelName,
+        default_system_prompt: systemPrompt,
+        default_model_settings: modelSettings,
+    };
+
+    try {
+        const response = await fetch('/v1/api/agents/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            const errorData = await safeJson(response);
+            const message = errorData?.detail || `HTTP error! status: ${response.status}`;
+            throw new Error(message);
+        }
+
+        bootstrap.Modal.getInstance(document.getElementById('createAgentModal')).hide();
+        showAlert('Agent created successfully.', 'success');
+        loadAgents();
+    } catch (error) {
+        console.error('Error creating agent:', error);
+        showModalAlert('createAgentAlert', 'Error creating agent: ' + error.message, 'danger');
+    }
+}
+
+function openEditAgent(agentId) {
+    const agent = agents.find((item) => item.id === agentId);
+    if (!agent) {
+        showAlert('Unable to locate agent for editing.', 'danger');
+        return;
+    }
+
+    document.getElementById('editAgentId').value = agent.id;
+    document.getElementById('editAgentName').value = agent.name;
+    document.getElementById('editAgentDescription').value = agent.description || '';
+    document.getElementById('editAgentModelName').value = agent.default_model_name || '';
+    document.getElementById('editAgentSystemPrompt').value = agent.default_system_prompt || '';
+    document.getElementById('editAgentModelSettings').value = agent.default_model_settings
+        ? JSON.stringify(agent.default_model_settings, null, 2)
+        : '';
+
+    clearModalAlert('editAgentAlert');
+    const modal = new bootstrap.Modal(document.getElementById('editAgentModal'));
+    modal.show();
+}
+
+async function updateAgent() {
+    const agentId = document.getElementById('editAgentId').value;
+    const name = document.getElementById('editAgentName').value.trim();
+    const modelName = document.getElementById('editAgentModelName').value.trim();
+    const systemPrompt = document.getElementById('editAgentSystemPrompt').value.trim();
+    const modelSettingsText = document.getElementById('editAgentModelSettings').value.trim();
+
+    if (!name || !modelName || !systemPrompt) {
+        showModalAlert('editAgentAlert', 'Name, default model, and system prompt are required.', 'warning');
+        return;
+    }
+
+    let modelSettings = {};
+    try {
+        modelSettings = parseJsonOrThrow(modelSettingsText, {});
+    } catch (error) {
+        showModalAlert('editAgentAlert', error.message, 'danger');
+        return;
+    }
+
+    const payload = {
+        name: name,
+        description: document.getElementById('editAgentDescription').value.trim() || null,
+        default_model_name: modelName,
+        default_system_prompt: systemPrompt,
+        default_model_settings: modelSettings,
+    };
+
+    try {
+        const response = await fetch(`/v1/api/agents/${agentId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            const errorData = await safeJson(response);
+            const message = errorData?.detail || `HTTP error! status: ${response.status}`;
+            throw new Error(message);
+        }
+
+        bootstrap.Modal.getInstance(document.getElementById('editAgentModal')).hide();
+        showAlert('Agent updated successfully.', 'success');
+        loadAgents();
+    } catch (error) {
+        console.error('Error updating agent:', error);
+        showModalAlert('editAgentAlert', 'Error updating agent: ' + error.message, 'danger');
+    }
+}
+
+async function archiveAgent(agentId) {
+    if (!confirm('Archive this agent? All associated test cases will be hidden until you restore it.')) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`/v1/api/agents/${agentId}`, {
+            method: 'DELETE',
+        });
+
+        if (!response.ok) {
+            const errorData = await safeJson(response);
+            const message = errorData?.detail || `HTTP error! status: ${response.status}`;
+            throw new Error(message);
+        }
+
+        showAlert('Agent archived successfully.', 'success');
+        loadAgents();
+    } catch (error) {
+        console.error('Error archiving agent:', error);
+        showAlert('Error archiving agent: ' + error.message, 'danger');
+    }
+}
+
+async function restoreAgent(agentId) {
+    try {
+        const response = await fetch(`/v1/api/agents/${agentId}/restore`, {
+            method: 'POST',
+        });
+
+        if (!response.ok) {
+            const errorData = await safeJson(response);
+            const message = errorData?.detail || `HTTP error! status: ${response.status}`;
+            throw new Error(message);
+        }
+
+        showAlert('Agent restored successfully.', 'success');
+        loadAgents();
+    } catch (error) {
+        console.error('Error restoring agent:', error);
+        showAlert('Error restoring agent: ' + error.message, 'danger');
+    }
+}
+
+function openAgentTestCases(agentId) {
+    window.open(`/test-cases?agentId=${encodeURIComponent(agentId)}`, '_blank');
+}
+
+// Helpers
+function toggleLoading(show) {
+    const spinner = document.getElementById('loadingSpinner');
+    const table = document.getElementById('agentsTable');
+    if (!spinner || !table) {
+        return;
+    }
+
+    if (show) {
+        spinner.classList.remove('d-none');
+        table.classList.add('d-none');
+    } else {
+        spinner.classList.add('d-none');
+        table.classList.remove('d-none');
+    }
+}
+
+function parseJsonOrThrow(text, fallback) {
+    if (!text) {
+        return fallback;
+    }
+
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        throw new Error('Model settings must be valid JSON. ' + error.message);
+    }
+}
+
+async function safeJson(response) {
+    try {
+        return await response.json();
+    } catch (error) {
+        return null;
+    }
+}
+
+function showAlert(message, type) {
+    const container = document.querySelector('.container');
+    if (!container) return;
+
+    const alert = document.createElement('div');
+    alert.className = `alert alert-${type} alert-dismissible fade show`;
+    alert.innerHTML = `
+        ${message}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    `;
+
+    container.insertBefore(alert, container.firstChild);
+
+    setTimeout(() => {
+        if (alert.parentNode) {
+            alert.remove();
+        }
+    }, 6000);
+}
+
+function showModalAlert(containerId, message, type) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    container.innerHTML = `
+        <div class="alert alert-${type}" role="alert">
+            ${message}
+        </div>
+    `;
+}
+
+function clearModalAlert(containerId) {
+    const container = document.getElementById(containerId);
+    if (container) {
+        container.innerHTML = '';
+    }
+}
+
+function escapeHtml(text) {
+    if (text === null || text === undefined) {
+        return '';
+    }
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function truncateText(text, maxLength) {
+    if (!text) return '';
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + '…';
+}
+
+function formatDate(dateString) {
+    if (!dateString) {
+        return '<span class="text-muted">—</span>';
+    }
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return escapeHtml(dateString);
+    }
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+}
+
+// expose functions used by inline handlers
+window.openEditAgent = openEditAgent;
+window.archiveAgent = archiveAgent;
+window.restoreAgent = restoreAgent;
+window.openAgentTestCases = openAgentTestCases;

--- a/static/js/agents.js
+++ b/static/js/agents.js
@@ -84,9 +84,9 @@ function displayAgents(agentList) {
 
     const rows = agentList
         .map((agent) => {
-            const description = agent.description
-                ? `<small class="text-muted">${escapeHtml(truncateText(agent.description, 80))}</small>`
-                : '';
+            const descriptionHtml = agent.description
+                ? `<div class="text-muted small text-break">${escapeHtml(truncateText(agent.description, 160))}</div>`
+                : '<span class="text-muted">—</span>';
             const systemPrompt = agent.default_system_prompt
                 ? `<div class="text-truncate" style="max-width: 260px;" title="${escapeHtml(agent.default_system_prompt)}">${escapeHtml(truncateText(agent.default_system_prompt, 120))}</div>`
                 : '<span class="text-muted">—</span>';
@@ -103,9 +103,9 @@ function displayAgents(agentList) {
                         <div class="d-flex align-items-center gap-2">
                             <strong>${escapeHtml(agent.name)}</strong>
                         </div>
-                        ${description}
                     </div>
                 </td>
+                <td>${descriptionHtml}</td>
                 <td>
                     <div class="d-flex flex-column gap-1">
                         <span class="badge bg-primary">${escapeHtml(agent.default_model_name || 'Not set')}</span>
@@ -119,7 +119,6 @@ function displayAgents(agentList) {
                         <small class="text-muted">Created ${formatDate(agent.created_at)}</small>
                     </div>
                 </td>
-                <td><span class="badge bg-success">Active</span></td>
                 <td class="text-end">
                     <div class="btn-group btn-group-sm" role="group">
                         <button type="button" class="btn btn-outline-primary" onclick="openEditAgent('${agent.id}')">

--- a/static/js/agents.js
+++ b/static/js/agents.js
@@ -94,7 +94,7 @@ function displayAgents(agentList) {
                 ? `<code class="text-muted">${escapeHtml(truncateText(JSON.stringify(agent.default_model_settings), 120))}</code>`
                 : '<span class="text-muted">Inherited per case</span>';
 
-            const updatedAt = formatDate(agent.updated_at);
+            const createdAt = formatDate(agent.created_at);
 
             return `
             <tr>
@@ -115,8 +115,7 @@ function displayAgents(agentList) {
                 </td>
                 <td>
                     <div class="d-flex flex-column">
-                        <span>${updatedAt}</span>
-                        <small class="text-muted">Created ${formatDate(agent.created_at)}</small>
+                        <span>${createdAt}</span>
                     </div>
                 </td>
                 <td class="text-end">

--- a/static/js/agents.js
+++ b/static/js/agents.js
@@ -349,23 +349,32 @@ async function safeJson(response) {
 }
 
 function showAlert(message, type) {
-    const container = document.querySelector('.container');
-    if (!container) return;
-
-    const alert = document.createElement('div');
-    alert.className = `alert alert-${type} alert-dismissible fade show`;
-    alert.innerHTML = `
+    const alertDiv = document.createElement('div');
+    alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
+    alertDiv.innerHTML = `
         ${message}
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
     `;
 
-    container.insertBefore(alert, container.firstChild);
+    const toastRoot = document.getElementById('toast-root');
+    if (toastRoot) {
+        toastRoot.appendChild(alertDiv);
+    } else {
+        const container = document.querySelector('.container');
+        if (container) {
+            if (container.firstChild) {
+                container.insertBefore(alertDiv, container.firstChild);
+            } else {
+                container.appendChild(alertDiv);
+            }
+        }
+    }
 
     setTimeout(() => {
-        if (alert.parentNode) {
-            alert.remove();
+        if (alertDiv.parentNode) {
+            alertDiv.remove();
         }
-    }, 6000);
+    }, 5000);
 }
 
 function showModalAlert(containerId, message, type) {

--- a/static/js/agents.js
+++ b/static/js/agents.js
@@ -120,6 +120,9 @@ function displayAgents(agentList) {
                 </td>
                 <td class="text-end">
                     <div class="btn-group btn-group-sm" role="group">
+                        <button type="button" class="btn btn-outline-info" onclick="viewAgentDetails('${agent.id}')" title="View details">
+                            <i class="fas fa-eye"></i>
+                        </button>
                         <button type="button" class="btn btn-outline-primary" onclick="openEditAgent('${agent.id}')">
                             <i class="fas fa-edit"></i>
                         </button>
@@ -409,7 +412,12 @@ function formatDate(dateString) {
     return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
 }
 
+function viewAgentDetails(agentId) {
+    window.open(`/agents/${agentId}`, '_blank');
+}
+
 // expose functions used by inline handlers
 window.openEditAgent = openEditAgent;
+window.viewAgentDetails = viewAgentDetails;
 window.deleteAgent = deleteAgent;
 window.openAgentTestCases = openAgentTestCases;

--- a/static/js/regression-test-detail.js
+++ b/static/js/regression-test-detail.js
@@ -1,0 +1,233 @@
+/**
+ * Regression Test Detail JavaScript
+ *
+ * Displays regression metadata and associated logs.
+ */
+
+window.addEventListener('DOMContentLoaded', () => {
+    setupEventListeners();
+    loadRegressionDetail();
+    loadRegressionLogs();
+});
+
+function setupEventListeners() {
+    const refreshBtn = document.getElementById('refreshDetailBtn');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', () => {
+            loadRegressionDetail();
+            loadRegressionLogs();
+        });
+    }
+
+    const refreshLogsBtn = document.getElementById('refreshLogsBtn');
+    if (refreshLogsBtn) {
+        refreshLogsBtn.addEventListener('click', () => loadRegressionLogs());
+    }
+}
+
+async function loadRegressionDetail() {
+    toggleDetailLoading(true);
+    try {
+        const response = await fetch(`/v1/api/regression-tests/${regressionId}`);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const regression = await response.json();
+        displayRegressionDetail(regression);
+    } catch (error) {
+        console.error('Error loading regression test:', error);
+        showDetailError('Failed to load regression test details: ' + error.message);
+    } finally {
+        toggleDetailLoading(false);
+    }
+}
+
+function displayRegressionDetail(regression) {
+    const content = document.getElementById('regressionContent');
+    const errorMessage = document.getElementById('errorMessage');
+    if (!content) return;
+
+    errorMessage.classList.add('d-none');
+    content.classList.remove('d-none');
+
+    setText('regressionId', regression.id);
+    setText('agentName', regression.agent ? regression.agent.name : 'Unknown agent');
+    setHtml('statusBadge', buildStatusBadge(regression.status));
+    setHtml('startedAt', formatDate(regression.started_at));
+    setHtml('completedAt', formatDate(regression.completed_at));
+    setHtml('totalCount', regression.total_count);
+    setHtml('successCount', regression.success_count);
+    setHtml('failedCount', regression.failed_count);
+
+    setText('overrideModel', regression.model_name_override);
+    setPre('overridePrompt', regression.system_prompt_override || '');
+    const settingsPretty = JSON.stringify(regression.model_settings_override || {}, null, 2);
+    setPre('overrideSettings', settingsPretty);
+
+    const openLogsBtn = document.getElementById('openLogsBtn');
+    const viewAllLogsBtn = document.getElementById('viewAllLogsBtn');
+    const logsLink = `/test-logs?regressionTestId=${encodeURIComponent(regression.id)}`;
+    if (openLogsBtn) openLogsBtn.href = logsLink;
+    if (viewAllLogsBtn) viewAllLogsBtn.href = logsLink;
+
+    const errorSection = document.getElementById('errorSection');
+    const errorMessageText = document.getElementById('errorMessageText');
+    if (regression.error_message) {
+        errorSection.classList.remove('d-none');
+        if (errorMessageText) {
+            errorMessageText.textContent = regression.error_message;
+        }
+    } else {
+        errorSection.classList.add('d-none');
+    }
+}
+
+async function loadRegressionLogs() {
+    const logsContainer = document.getElementById('logsList');
+    if (logsContainer) {
+        logsContainer.innerHTML = '<tr><td colspan="5" class="text-muted">Loading logs...</td></tr>';
+    }
+
+    try {
+        const response = await fetch(`/v1/api/regression-tests/${regressionId}/logs?limit=50`);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const logs = await response.json();
+        displayRegressionLogs(logs);
+    } catch (error) {
+        console.error('Error loading regression logs:', error);
+        showDetailError('Failed to load regression logs: ' + error.message);
+    }
+}
+
+function displayRegressionLogs(logs) {
+    const list = document.getElementById('logsList');
+    const emptyState = document.getElementById('logsEmptyState');
+    if (!list || !emptyState) return;
+
+    if (!logs || logs.length === 0) {
+        list.innerHTML = '';
+        emptyState.classList.remove('d-none');
+        return;
+    }
+
+    emptyState.classList.add('d-none');
+
+    const rows = logs
+        .map((log) => {
+            const statusBadge = buildLogStatusBadge(log.status);
+            const executedAt = formatDate(log.created_at);
+            const responseTime = log.response_time_ms != null ? `${log.response_time_ms} ms` : '—';
+            return `
+            <tr>
+                <td>
+                    <div class="d-flex flex-column">
+                        <a href="/test-cases/${log.test_case_id}" target="_blank" class="fw-semibold text-decoration-none">
+                            ${escapeHtml(log.test_case_id)}
+                        </a>
+                        <small class="text-muted">Log ID: ${escapeHtml(log.id)}</small>
+                    </div>
+                </td>
+                <td>${statusBadge}</td>
+                <td><span class="badge bg-primary">${escapeHtml(log.model_name)}</span></td>
+                <td>${responseTime}</td>
+                <td>${executedAt}</td>
+            </tr>`;
+        })
+        .join('');
+
+    list.innerHTML = rows;
+}
+
+function toggleDetailLoading(show) {
+    const spinner = document.getElementById('loadingSpinner');
+    const content = document.getElementById('regressionContent');
+    if (!spinner || !content) return;
+
+    if (show) {
+        spinner.classList.remove('d-none');
+        content.classList.add('d-none');
+    } else {
+        spinner.classList.add('d-none');
+    }
+}
+
+function showDetailError(message) {
+    const errorBox = document.getElementById('errorMessage');
+    const errorText = document.getElementById('errorText');
+    if (!errorBox || !errorText) return;
+
+    errorText.textContent = message;
+    errorBox.classList.remove('d-none');
+}
+
+function setText(elementId, value) {
+    const element = document.getElementById(elementId);
+    if (element) {
+        element.textContent = value || '';
+    }
+}
+
+function setHtml(elementId, value) {
+    const element = document.getElementById(elementId);
+    if (element) {
+        element.innerHTML = value;
+    }
+}
+
+function setPre(elementId, value) {
+    const element = document.getElementById(elementId);
+    if (element) {
+        element.textContent = value;
+    }
+}
+
+function buildStatusBadge(status) {
+    const normalized = (status || '').toLowerCase();
+    switch (normalized) {
+        case 'pending':
+            return '<span class="badge bg-secondary"><i class="fas fa-clock me-1"></i>Pending</span>';
+        case 'running':
+            return '<span class="badge bg-warning"><i class="fas fa-spinner fa-spin me-1"></i>Running</span>';
+        case 'completed':
+            return '<span class="badge bg-success"><i class="fas fa-check me-1"></i>Completed</span>';
+        case 'failed':
+            return '<span class="badge bg-danger"><i class="fas fa-triangle-exclamation me-1"></i>Failed</span>';
+        default:
+            return `<span class="badge bg-secondary">${escapeHtml(status)}</span>`;
+    }
+}
+
+function buildLogStatusBadge(status) {
+    const normalized = (status || '').toLowerCase();
+    if (normalized === 'success') {
+        return '<span class="badge bg-success"><i class="fas fa-check me-1"></i>Success</span>';
+    }
+    if (normalized === 'failed') {
+        return '<span class="badge bg-danger"><i class="fas fa-times me-1"></i>Failed</span>';
+    }
+    return `<span class="badge bg-secondary">${escapeHtml(status)}</span>`;
+}
+
+function escapeHtml(text) {
+    if (text === null || text === undefined) {
+        return '';
+    }
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function formatDate(dateString) {
+    if (!dateString) {
+        return '<span class="text-muted">—</span>';
+    }
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return escapeHtml(dateString);
+    }
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+}

--- a/static/js/regression-tests.js
+++ b/static/js/regression-tests.js
@@ -1,0 +1,447 @@
+/**
+ * Regression Tests Management JavaScript
+ *
+ * Coordinates regression history listing and launching new runs.
+ */
+
+let regressionTests = [];
+let agentOptions = [];
+let currentFilters = { agentId: '', status: '' };
+let refreshTimeout = null;
+
+window.addEventListener('DOMContentLoaded', () => {
+    setupEventListeners();
+    initializeData();
+});
+
+async function initializeData() {
+    await loadAgents();
+    await loadRegressions();
+}
+
+function setupEventListeners() {
+    const refreshBtn = document.getElementById('refreshRegressionsBtn');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', () => loadRegressions());
+    }
+
+    const applyFiltersBtn = document.getElementById('applyFiltersBtn');
+    if (applyFiltersBtn) {
+        applyFiltersBtn.addEventListener('click', () => {
+            const agentFilter = document.getElementById('agentFilter');
+            const statusFilter = document.getElementById('statusFilter');
+            currentFilters.agentId = agentFilter ? agentFilter.value : '';
+            currentFilters.status = statusFilter ? statusFilter.value : '';
+            loadRegressions();
+        });
+    }
+
+    const clearFiltersBtn = document.getElementById('clearFiltersBtn');
+    if (clearFiltersBtn) {
+        clearFiltersBtn.addEventListener('click', () => {
+            const agentFilter = document.getElementById('agentFilter');
+            const statusFilter = document.getElementById('statusFilter');
+            if (agentFilter) agentFilter.value = '';
+            if (statusFilter) statusFilter.value = '';
+            currentFilters = { agentId: '', status: '' };
+            loadRegressions();
+        });
+    }
+
+    const startRegressionBtn = document.getElementById('confirmStartRegression');
+    if (startRegressionBtn) {
+        startRegressionBtn.addEventListener('click', startRegression);
+    }
+
+    const regressionAgentSelect = document.getElementById('regressionAgentSelect');
+    if (regressionAgentSelect) {
+        regressionAgentSelect.addEventListener('change', (event) => populateDefaultsForAgent(event.target.value));
+    }
+
+    const startModal = document.getElementById('startRegressionModal');
+    if (startModal) {
+        startModal.addEventListener('shown.bs.modal', () => {
+            clearModalAlert('startRegressionAlert');
+            const settingsInput = document.getElementById('regressionModelSettings');
+            if (settingsInput && !settingsInput.value.trim()) {
+                settingsInput.value = '{}';
+            }
+            if (agentOptions.length === 1) {
+                document.getElementById('regressionAgentSelect').value = agentOptions[0].id;
+                populateDefaultsForAgent(agentOptions[0].id);
+            }
+        });
+
+        startModal.addEventListener('hidden.bs.modal', () => {
+            document.getElementById('startRegressionForm').reset();
+            clearModalAlert('startRegressionAlert');
+        });
+    }
+
+}
+
+async function loadAgents() {
+    try {
+        const response = await fetch('/v1/api/agents/');
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const agents = await response.json();
+        agentOptions = agents.filter((agent) => !agent.is_deleted);
+        populateAgentFilter(agentOptions);
+        populateRegressionAgentSelect(agentOptions);
+        updateRegressionNotice();
+    } catch (error) {
+        console.error('Error loading agents:', error);
+        showAlert('Error loading agents: ' + error.message, 'danger');
+    }
+}
+
+async function loadRegressions() {
+    toggleLoading(true);
+    if (refreshTimeout) {
+        clearTimeout(refreshTimeout);
+        refreshTimeout = null;
+    }
+
+    try {
+        const url = new URL('/v1/api/regression-tests/', window.location.origin);
+        if (currentFilters.agentId) {
+            url.searchParams.append('agent_id', currentFilters.agentId);
+        }
+        if (currentFilters.status) {
+            url.searchParams.append('status', currentFilters.status);
+        }
+        url.searchParams.append('limit', '100');
+
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        regressionTests = await response.json();
+        displayRegressionTests(regressionTests);
+        scheduleAutoRefresh(regressionTests);
+    } catch (error) {
+        console.error('Error loading regression tests:', error);
+        showAlert('Error loading regression tests: ' + error.message, 'danger');
+    } finally {
+        toggleLoading(false);
+    }
+}
+
+function displayRegressionTests(regressions) {
+    const container = document.getElementById('regressionTestsList');
+    const table = document.getElementById('regressionTestsTable');
+    const emptyState = document.getElementById('emptyState');
+
+    if (!container || !table || !emptyState) {
+        return;
+    }
+
+    if (!regressions || regressions.length === 0) {
+        container.innerHTML = '';
+        table.style.display = 'none';
+        emptyState.classList.remove('d-none');
+        return;
+    }
+
+    emptyState.classList.add('d-none');
+    table.style.display = 'table';
+
+    const rows = regressions
+        .map((regression) => {
+            const statusBadge = buildStatusBadge(regression.status);
+            const agentName = regression.agent ? regression.agent.name : 'Unknown agent';
+            const overrides = `
+                <div class="d-flex flex-column gap-1">
+                    <span class="badge bg-primary">${escapeHtml(regression.model_name_override)}</span>
+                    <small class="text-muted text-truncate" style="max-width: 260px;" title="${escapeHtml(regression.system_prompt_override)}">
+                        ${escapeHtml(truncateText(regression.system_prompt_override, 120))}
+                    </small>
+                </div>
+            `;
+            const settings = `<code class="text-muted">${escapeHtml(truncateText(JSON.stringify(regression.model_settings_override), 120))}</code>`;
+            const results = `
+                <div class="d-flex flex-wrap gap-2">
+                    <span class="badge bg-primary">Total ${regression.total_count}</span>
+                    <span class="badge bg-success">Passed ${regression.success_count}</span>
+                    <span class="badge bg-danger">Failed ${regression.failed_count}</span>
+                </div>
+            `;
+
+            const started = formatDate(regression.started_at);
+            const completed = formatDate(regression.completed_at);
+            const timing = `
+                <div class="d-flex flex-column">
+                    <span><strong>Start:</strong> ${started}</span>
+                    <span><strong>End:</strong> ${completed}</span>
+                </div>
+            `;
+
+            return `
+            <tr>
+                <td>
+                    <div class="d-flex flex-column">
+                        <strong>${escapeHtml(agentName)}</strong>
+                        <small class="text-muted">${regression.id}</small>
+                    </div>
+                </td>
+                <td>${statusBadge}</td>
+                <td>
+                    ${overrides}
+                    <div class="small mt-2">${settings}</div>
+                </td>
+                <td>${results}</td>
+                <td>${timing}</td>
+                <td class="text-end">
+                    <div class="btn-group btn-group-sm" role="group">
+                        <button type="button" class="btn btn-outline-primary" onclick="openRegressionDetail('${regression.id}')">
+                            <i class="fas fa-eye"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" onclick="loadRegressions()" title="Refresh list">
+                            <i class="fas fa-rotate"></i>
+                        </button>
+                    </div>
+                </td>
+            </tr>`;
+        })
+        .join('');
+
+    container.innerHTML = rows;
+}
+
+function buildStatusBadge(status) {
+    const normalized = (status || '').toLowerCase();
+    switch (normalized) {
+        case 'pending':
+            return '<span class="badge bg-secondary"><i class="fas fa-clock me-1"></i>Pending</span>';
+        case 'running':
+            return '<span class="badge bg-warning"><i class="fas fa-spinner fa-spin me-1"></i>Running</span>';
+        case 'completed':
+            return '<span class="badge bg-success"><i class="fas fa-check me-1"></i>Completed</span>';
+        case 'failed':
+            return '<span class="badge bg-danger"><i class="fas fa-triangle-exclamation me-1"></i>Failed</span>';
+        default:
+            return `<span class="badge bg-secondary">${escapeHtml(status)}</span>`;
+    }
+}
+
+function populateAgentFilter(agents) {
+    const filter = document.getElementById('agentFilter');
+    if (!filter) return;
+
+    filter.innerHTML = '<option value="">All agents</option>';
+    agents.forEach((agent) => {
+        const option = document.createElement('option');
+        option.value = agent.id;
+        option.textContent = agent.name;
+        filter.appendChild(option);
+    });
+
+    if (currentFilters.agentId) {
+        filter.value = currentFilters.agentId;
+    }
+}
+
+function populateRegressionAgentSelect(agents) {
+    const select = document.getElementById('regressionAgentSelect');
+    const startButton = document.getElementById('startRegressionBtn');
+    if (!select) return;
+
+    select.innerHTML = '<option value="">Select an agent...</option>';
+    agents.forEach((agent) => {
+        const option = document.createElement('option');
+        option.value = agent.id;
+        option.textContent = agent.name;
+        select.appendChild(option);
+    });
+
+    if (startButton) {
+        startButton.disabled = agents.length === 0;
+    }
+}
+
+function populateDefaultsForAgent(agentId) {
+    if (!agentId) {
+        return;
+    }
+
+    const agent = agentOptions.find((item) => item.id === agentId);
+    if (!agent) {
+        return;
+    }
+
+    document.getElementById('regressionModelName').value = agent.default_model_name || '';
+    document.getElementById('regressionSystemPrompt').value = agent.default_system_prompt || '';
+    const settings = agent.default_model_settings ? JSON.stringify(agent.default_model_settings, null, 2) : '{}';
+    document.getElementById('regressionModelSettings').value = settings;
+}
+
+async function startRegression() {
+    const agentSelect = document.getElementById('regressionAgentSelect');
+    const modelNameInput = document.getElementById('regressionModelName');
+    const systemPromptInput = document.getElementById('regressionSystemPrompt');
+    const modelSettingsInput = document.getElementById('regressionModelSettings');
+
+    const agentId = agentSelect.value;
+    const modelName = modelNameInput.value.trim();
+    const systemPrompt = systemPromptInput.value.trim();
+    const modelSettingsText = modelSettingsInput.value.trim();
+
+    if (!agentId || !modelName || !systemPrompt || !modelSettingsText) {
+        showModalAlert('startRegressionAlert', 'All override fields are required.', 'warning');
+        return;
+    }
+
+    let modelSettings;
+    try {
+        modelSettings = JSON.parse(modelSettingsText);
+    } catch (error) {
+        showModalAlert('startRegressionAlert', 'Model settings must be valid JSON. ' + error.message, 'danger');
+        return;
+    }
+
+    const payload = {
+        agent_id: agentId,
+        model_name_override: modelName,
+        system_prompt_override: systemPrompt,
+        model_settings_override: modelSettings,
+    };
+
+    try {
+        const response = await fetch('/v1/api/regression-tests/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            const errorData = await safeJson(response);
+            const message = errorData?.detail || `HTTP error! status: ${response.status}`;
+            throw new Error(message);
+        }
+
+        bootstrap.Modal.getInstance(document.getElementById('startRegressionModal')).hide();
+        showAlert('Regression run started successfully.', 'success');
+        loadRegressions();
+    } catch (error) {
+        console.error('Error starting regression:', error);
+        showModalAlert('startRegressionAlert', 'Error starting regression: ' + error.message, 'danger');
+    }
+}
+
+function scheduleAutoRefresh(regressions) {
+    const hasRunning = regressions.some((item) => ['pending', 'running'].includes((item.status || '').toLowerCase()));
+    if (hasRunning) {
+        refreshTimeout = setTimeout(() => {
+            loadRegressions();
+        }, 10000);
+    }
+}
+
+function updateRegressionNotice() {
+    const notice = document.getElementById('regressionNotice');
+    if (!notice) return;
+
+    if (agentOptions.length === 0) {
+        notice.classList.add('d-none');
+    } else {
+        notice.classList.remove('d-none');
+    }
+}
+
+function openRegressionDetail(regressionId) {
+    window.open(`/regression-tests/${regressionId}`, '_blank');
+}
+
+function toggleLoading(show) {
+    const spinner = document.getElementById('loadingSpinner');
+    const table = document.getElementById('regressionTestsTable');
+    if (!spinner || !table) return;
+
+    if (show) {
+        spinner.classList.remove('d-none');
+        table.classList.add('d-none');
+    } else {
+        spinner.classList.add('d-none');
+        table.classList.remove('d-none');
+    }
+}
+
+async function safeJson(response) {
+    try {
+        return await response.json();
+    } catch (error) {
+        return null;
+    }
+}
+
+function showAlert(message, type) {
+    const container = document.querySelector('.container');
+    if (!container) return;
+
+    const alert = document.createElement('div');
+    alert.className = `alert alert-${type} alert-dismissible fade show`;
+    alert.innerHTML = `
+        ${message}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    `;
+
+    container.insertBefore(alert, container.firstChild);
+
+    setTimeout(() => {
+        if (alert.parentNode) {
+            alert.remove();
+        }
+    }, 6000);
+}
+
+function showModalAlert(containerId, message, type) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    container.innerHTML = `
+        <div class="alert alert-${type}" role="alert">
+            ${message}
+        </div>
+    `;
+}
+
+function clearModalAlert(containerId) {
+    const container = document.getElementById(containerId);
+    if (container) {
+        container.innerHTML = '';
+    }
+}
+
+function escapeHtml(text) {
+    if (text === null || text === undefined) {
+        return '';
+    }
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+function truncateText(text, maxLength) {
+    if (!text) return '';
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + '…';
+}
+
+function formatDate(dateString) {
+    if (!dateString) {
+        return '<span class="text-muted">—</span>';
+    }
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return escapeHtml(dateString);
+    }
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+}
+
+window.openRegressionDetail = openRegressionDetail;

--- a/static/js/regression-tests.js
+++ b/static/js/regression-tests.js
@@ -25,17 +25,6 @@ function setupEventListeners() {
         refreshBtn.addEventListener('click', () => loadRegressions());
     }
 
-    const applyFiltersBtn = document.getElementById('applyFiltersBtn');
-    if (applyFiltersBtn) {
-        applyFiltersBtn.addEventListener('click', () => {
-            const agentFilter = document.getElementById('agentFilter');
-            const statusFilter = document.getElementById('statusFilter');
-            currentFilters.agentId = agentFilter ? agentFilter.value : '';
-            currentFilters.status = statusFilter ? statusFilter.value : '';
-            loadRegressions();
-        });
-    }
-
     const clearFiltersBtn = document.getElementById('clearFiltersBtn');
     if (clearFiltersBtn) {
         clearFiltersBtn.addEventListener('click', () => {
@@ -46,6 +35,24 @@ function setupEventListeners() {
             currentFilters = { agentId: '', status: '' };
             loadRegressions();
         });
+    }
+
+    const agentFilter = document.getElementById('agentFilter');
+    if (agentFilter) {
+        agentFilter.addEventListener('change', (event) => {
+            currentFilters.agentId = event.target.value;
+            loadRegressions();
+        });
+        agentFilter.value = currentFilters.agentId;
+    }
+
+    const statusFilter = document.getElementById('statusFilter');
+    if (statusFilter) {
+        statusFilter.addEventListener('change', (event) => {
+            currentFilters.status = event.target.value;
+            loadRegressions();
+        });
+        statusFilter.value = currentFilters.status;
     }
 
     const startRegressionBtn = document.getElementById('confirmStartRegression');

--- a/static/js/regression-tests.js
+++ b/static/js/regression-tests.js
@@ -478,23 +478,32 @@ async function safeJson(response) {
 }
 
 function showAlert(message, type) {
-    const container = document.querySelector('.container');
-    if (!container) return;
-
-    const alert = document.createElement('div');
-    alert.className = `alert alert-${type} alert-dismissible fade show`;
-    alert.innerHTML = `
+    const alertDiv = document.createElement('div');
+    alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
+    alertDiv.innerHTML = `
         ${message}
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
     `;
 
-    container.insertBefore(alert, container.firstChild);
+    const toastRoot = document.getElementById('toast-root');
+    if (toastRoot) {
+        toastRoot.appendChild(alertDiv);
+    } else {
+        const container = document.querySelector('.container');
+        if (container) {
+            if (container.firstChild) {
+                container.insertBefore(alertDiv, container.firstChild);
+            } else {
+                container.appendChild(alertDiv);
+            }
+        }
+    }
 
     setTimeout(() => {
-        if (alert.parentNode) {
-            alert.remove();
+        if (alertDiv.parentNode) {
+            alertDiv.remove();
         }
-    }, 6000);
+    }, 5000);
 }
 
 function showModalAlert(containerId, message, type) {

--- a/static/js/regression-tests.js
+++ b/static/js/regression-tests.js
@@ -317,6 +317,13 @@ async function startRegression() {
         model_settings_override: modelSettings,
     };
 
+    const confirmButton = document.getElementById('confirmStartRegression');
+    if (confirmButton) {
+        confirmButton.disabled = true;
+        confirmButton.dataset.originalText = confirmButton.innerHTML;
+        confirmButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status"></span>Launching…';
+    }
+
     try {
         const response = await fetch('/v1/api/regression-tests/', {
             method: 'POST',
@@ -338,6 +345,12 @@ async function startRegression() {
     } catch (error) {
         console.error('Error starting regression:', error);
         showModalAlert('startRegressionAlert', 'Error starting regression: ' + error.message, 'danger');
+    } finally {
+        if (confirmButton) {
+            confirmButton.disabled = false;
+            confirmButton.innerHTML = confirmButton.dataset.originalText || confirmButton.innerHTML;
+            delete confirmButton.dataset.originalText;
+        }
     }
 }
 

--- a/static/js/regression-tests.js
+++ b/static/js/regression-tests.js
@@ -98,7 +98,6 @@ async function loadAgents() {
         agentOptions = agents.filter((agent) => !agent.is_deleted);
         populateAgentFilter(agentOptions);
         populateRegressionAgentSelect(agentOptions);
-        updateRegressionNotice();
     } catch (error) {
         console.error('Error loading agents:', error);
         showAlert('Error loading agents: ' + error.message, 'danger');
@@ -444,15 +443,6 @@ function updateRegressionRows(regressions) {
     });
 }
 
-function updateRegressionNotice() {
-    const notice = document.getElementById('regressionNotice');
-    if (!notice) return;
-
-    if (agentOptions.length === 0) {
-        notice.classList.add('d-none');
-    } else {
-        notice.classList.remove('d-none');
-    }
 }
 
 function openRegressionDetail(regressionId) {

--- a/static/js/test-cases.js
+++ b/static/js/test-cases.js
@@ -225,8 +225,10 @@ function displayTestCases(testCases) {
             </td>
             <td>
                 <div class="d-flex flex-column">
-                    <span>${agentDisplay}</span>
-                    <small class="text-muted">${escapeHtml(testCase.agent_id)}</small>
+                    ${testCase.agent ?
+                `<a href="/agents/${escapeHtml(testCase.agent_id)}" class="text-decoration-none" target="_blank">${agentDisplay}</a>` :
+                `<span class="text-muted">${agentDisplay}</span>`
+            }
                 </div>
             </td>
             <td>
@@ -581,7 +583,7 @@ async function viewTestCase(testCaseId) {
                     <table class="table table-sm">
                         <tr><td><strong>Name:</strong></td><td>${escapeHtml(testCase.name)}</td></tr>
                         <tr><td><strong>Description:</strong></td><td>${escapeHtml(testCase.description || 'N/A')}</td></tr>
-                        <tr><td><strong>Agent:</strong></td><td>${testCase.agent ? `<span class="badge bg-primary">${escapeHtml(testCase.agent.name)}</span>` : 'Unknown'}<br><small class="text-muted">${escapeHtml(testCase.agent_id)}</small></td></tr>
+                        <tr><td><strong>Agent:</strong></td><td>${testCase.agent ? `<a href="/agents/${escapeHtml(testCase.agent_id)}" class="badge bg-primary text-decoration-none" target="_blank">${escapeHtml(testCase.agent.name)}</a>` : '<span class="text-muted">Unknown</span>'}</td></tr>
                         <tr><td><strong>Model:</strong></td><td>${escapeHtml(testCase.model_name)}</td></tr>
                         <tr><td><strong>Has Tools:</strong></td><td>${testCase.tools ? 'Yes' : 'No'}</td></tr>
                         <tr><td><strong>Created:</strong></td><td>${formatDate(testCase.created_at)}</td></tr>

--- a/static/js/test-cases.js
+++ b/static/js/test-cases.js
@@ -62,6 +62,22 @@ function setupEventListeners() {
             loadTestCases();
         });
     }
+
+    const clearBtn = document.getElementById('clearFiltersBtn');
+    if (clearBtn) {
+        clearBtn.addEventListener('click', () => {
+            const agentSelect = document.getElementById('agentFilter');
+            const searchField = document.getElementById('searchInput');
+            selectedAgentId = '';
+            if (agentSelect) {
+                agentSelect.value = '';
+            }
+            if (searchField) {
+                searchField.value = '';
+            }
+            loadTestCases();
+        });
+    }
 }
 
 async function loadTestCases() {

--- a/static/js/test-cases.js
+++ b/static/js/test-cases.js
@@ -751,7 +751,6 @@ function showModalAlert(containerId, message, type) {
 }
 
 function showAlert(message, type) {
-    // Create alert element
     const alertDiv = document.createElement('div');
     alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
     alertDiv.innerHTML = `
@@ -759,11 +758,20 @@ function showAlert(message, type) {
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
     `;
 
-    // Insert at top of container
-    const container = document.querySelector('.container');
-    container.insertBefore(alertDiv, container.firstChild);
+    const toastRoot = document.getElementById('toast-root');
+    if (toastRoot) {
+        toastRoot.appendChild(alertDiv);
+    } else {
+        const container = document.querySelector('.container');
+        if (container) {
+            if (container.firstChild) {
+                container.insertBefore(alertDiv, container.firstChild);
+            } else {
+                container.appendChild(alertDiv);
+            }
+        }
+    }
 
-    // Auto-dismiss after 5 seconds
     setTimeout(() => {
         if (alertDiv.parentNode) {
             alertDiv.remove();

--- a/static/js/test-execution.js
+++ b/static/js/test-execution.js
@@ -595,7 +595,6 @@ function viewTestLog(logId) {
 
 // Utility functions
 function showAlert(message, type) {
-    // Create alert element
     const alertDiv = document.createElement('div');
     alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
     alertDiv.innerHTML = `
@@ -603,11 +602,20 @@ function showAlert(message, type) {
         <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
     `;
 
-    // Insert at top of container
-    const container = document.querySelector('.container');
-    container.insertBefore(alertDiv, container.firstChild);
+    const toastRoot = document.getElementById('toast-root');
+    if (toastRoot) {
+        toastRoot.appendChild(alertDiv);
+    } else {
+        const container = document.querySelector('.container');
+        if (container) {
+            if (container.firstChild) {
+                container.insertBefore(alertDiv, container.firstChild);
+            } else {
+                container.appendChild(alertDiv);
+            }
+        }
+    }
 
-    // Auto-dismiss after 5 seconds
     setTimeout(() => {
         if (alertDiv.parentNode) {
             alertDiv.remove();

--- a/static/js/test-logs.js
+++ b/static/js/test-logs.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     const urlParams = new URLSearchParams(window.location.search);
     const logId = urlParams.get('logId');
     const testCaseId = urlParams.get('testCaseId');
+    const regressionTestId = urlParams.get('regressionTestId');
 
     if (logId) {
         setTimeout(() => viewLogInNewPage(logId), 1000);
@@ -36,6 +37,16 @@ document.addEventListener('DOMContentLoaded', async function () {
             if (testCaseFilter) {
                 testCaseFilter.value = testCaseId;
                 currentFilters.testCaseId = testCaseId;
+                currentPage = 1;
+                loadTestLogs();
+            }
+        }, 1000);
+    } else if (regressionTestId) {
+        setTimeout(() => {
+            const regressionFilter = document.getElementById('regressionFilter');
+            if (regressionFilter) {
+                regressionFilter.value = regressionTestId;
+                currentFilters.regressionTestId = regressionTestId;
                 currentPage = 1;
                 loadTestLogs();
             }
@@ -310,16 +321,10 @@ function displayTestLogs(logs) {
         return `
         <tr>
             <td>
-                <div class="d-flex flex-column">
-                    <strong>${escapeHtml(testCaseName)}</strong>
-                    <small class="text-muted">Log ID: ${escapeHtml(log.id)}</small>
-                </div>
+                ${testCase ? `<a href="/test-cases/${escapeHtml(log.test_case_id)}" class="text-decoration-none" target="_blank"><strong>${escapeHtml(testCaseName)}</strong></a>` : `<span class="text-muted">${escapeHtml(testCaseName)}</span>`}
             </td>
             <td>
-                <div class="d-flex flex-column">
-                    <span class="badge bg-primary">${escapeHtml(agentName)}</span>
-                    <small class="text-muted">${escapeHtml(log.agent_id)}</small>
-                </div>
+                ${agent ? `<a href="/agents/${escapeHtml(log.agent_id)}" class="badge bg-primary text-decoration-none" target="_blank">${escapeHtml(agentName)}</a>` : `<span class="text-muted">${escapeHtml(agentName)}</span>`}
             </td>
             <td>${regressionLabel}</td>
             <td>

--- a/static/js/test-logs.js
+++ b/static/js/test-logs.js
@@ -238,12 +238,34 @@ function populateRegressionFilter(regressions) {
 
     select.innerHTML = '<option value="">All Regressions</option>';
     regressions.forEach((regression) => {
-        const label = regression.agent ? `${regression.agent.name} · ${regression.status}` : regression.status;
+        const agentName = regression.agent ? regression.agent.name : 'Unknown agent';
+        const timestamp = formatRegressionTimestamp(regression.created_at);
+        const label = `${agentName} · ${timestamp}`;
         const option = document.createElement('option');
         option.value = regression.id;
-        option.textContent = `${label} (${new Date(regression.created_at).toLocaleDateString()})`;
+        option.textContent = label;
         select.appendChild(option);
     });
+}
+
+function formatRegressionTimestamp(createdAt) {
+    if (!createdAt) {
+        return 'Unknown';
+    }
+    const date = new Date(createdAt);
+    if (Number.isNaN(date.getTime())) {
+        return 'Unknown';
+    }
+
+    const pad = (value) => String(value).padStart(2, '0');
+    const yyyy = date.getFullYear();
+    const MM = pad(date.getMonth() + 1);
+    const dd = pad(date.getDate());
+    const hh = pad(date.getHours());
+    const mm = pad(date.getMinutes());
+    const ss = pad(date.getSeconds());
+
+    return `${yyyy}${MM}${dd}${hh}${mm}${ss}`;
 }
 
 // Helper function to find test case by ID
@@ -278,9 +300,8 @@ function formatRegressionLabel(regressionId) {
         return `<a href="/regression-tests/${encodedId}" target="_blank">${escapeHtml(regressionId)}</a>`;
     }
 
-    const agentName = regression.agent ? regression.agent.name : null;
-    const status = regression.status || 'unknown';
-    const display = agentName ? `${agentName} · ${status}` : status;
+    const timestamp = formatRegressionTimestamp(regression.created_at);
+    const display = timestamp || regressionId;
     return `<a href="/regression-tests/${encodedId}" target="_blank">${escapeHtml(display)}</a>`;
 }
 

--- a/static/js/test-logs.js
+++ b/static/js/test-logs.js
@@ -369,7 +369,7 @@ function displayTestLogs(logs) {
                     <button type="button" class="btn btn-sm btn-outline-primary" onclick="viewLogInNewPage('${log.id}')" title="View Details">
                         <i class="fas fa-eye"></i>
                     </button>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="reExecuteTest('${log.test_case_id}')" title="Re-execute">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="reExecuteLog('${log.id}')" title="Re-execute">
                         <i class="fas fa-redo"></i>
                     </button>
                     <button type="button" class="btn btn-sm btn-outline-danger" onclick="deleteLog('${log.id}')" title="Delete">
@@ -537,14 +537,13 @@ function reExecuteTest(testCaseId) {
     window.location.href = `/test-execution?testCaseId=${testCaseId}`;
 }
 
+function reExecuteLog(logId) {
+    window.location.href = `/test-execution?logId=${logId}`;
+}
+
 function reExecuteFromLog() {
-    // Get the current log and redirect to execution page
     if (currentLogId) {
-        // We need to get the test case ID from the current log
-        const log = currentLogs.find(l => l.id === currentLogId);
-        if (log) {
-            reExecuteTest(log.test_case_id);
-        }
+        reExecuteLog(currentLogId);
     }
 }
 

--- a/static/js/test-logs.js
+++ b/static/js/test-logs.js
@@ -44,6 +44,15 @@ document.addEventListener('DOMContentLoaded', async function () {
 });
 
 function setupEventListeners() {
+    // Refresh button
+    const refreshTestLogsBtn = document.getElementById('refreshTestLogsBtn');
+    if (refreshTestLogsBtn) {
+        refreshTestLogsBtn.addEventListener('click', () => {
+            currentPage = 1;
+            loadTestLogs();
+        });
+    }
+
     // Clear filters button
     const clearFiltersBtn = document.getElementById('clearFiltersBtn');
     if (clearFiltersBtn) {

--- a/static/js/test-logs.js
+++ b/static/js/test-logs.js
@@ -602,19 +602,27 @@ function showLoading(show) {
 }
 
 function showAlert(message, type) {
-    // Create alert element
     const alertDiv = document.createElement('div');
-    alertDiv.className = `alert alert - ${type} alert - dismissible fade show`;
+    alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
     alertDiv.innerHTML = `
         ${message}
-    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
     `;
 
-    // Insert at top of container
-    const container = document.querySelector('.container');
-    container.insertBefore(alertDiv, container.firstChild);
+    const toastRoot = document.getElementById('toast-root');
+    if (toastRoot) {
+        toastRoot.appendChild(alertDiv);
+    } else {
+        const container = document.querySelector('.container');
+        if (container) {
+            if (container.firstChild) {
+                container.insertBefore(alertDiv, container.firstChild);
+            } else {
+                container.appendChild(alertDiv);
+            }
+        }
+    }
 
-    // Auto-dismiss after 5 seconds
     setTimeout(() => {
         if (alertDiv.parentNode) {
             alertDiv.remove();

--- a/static/js/test-logs.js
+++ b/static/js/test-logs.js
@@ -6,7 +6,7 @@
 
 let currentLogs = [];
 let currentPage = 1;
-let currentLimit = 100;
+let currentLimit = 50;
 let currentFilters = { status: '', testCaseId: '', agentId: '', regressionTestId: '' };
 let currentLogId = null;
 let testCasesData = []; // Store test cases data for lookup
@@ -32,19 +32,78 @@ document.addEventListener('DOMContentLoaded', async function () {
         setTimeout(() => viewLogInNewPage(logId), 1000);
     } else if (testCaseId) {
         setTimeout(() => {
-            document.getElementById('testCaseFilter').value = testCaseId;
-            applyFilters();
+            const testCaseFilter = document.getElementById('testCaseFilter');
+            if (testCaseFilter) {
+                testCaseFilter.value = testCaseId;
+                currentFilters.testCaseId = testCaseId;
+                currentPage = 1;
+                loadTestLogs();
+            }
         }, 1000);
     }
 });
 
 function setupEventListeners() {
-    // Limit selection
-    document.getElementById('limitSelect').addEventListener('change', function () {
-        currentLimit = parseInt(this.value);
-        currentPage = 1;
-        applyFilters();
-    });
+    // Clear filters button
+    const clearFiltersBtn = document.getElementById('clearFiltersBtn');
+    if (clearFiltersBtn) {
+        clearFiltersBtn.addEventListener('click', () => {
+            const statusFilter = document.getElementById('statusFilter');
+            const testCaseFilter = document.getElementById('testCaseFilter');
+            const agentFilter = document.getElementById('agentFilter');
+            const regressionFilter = document.getElementById('regressionFilter');
+
+            if (statusFilter) statusFilter.value = '';
+            if (testCaseFilter) testCaseFilter.value = '';
+            if (agentFilter) agentFilter.value = '';
+            if (regressionFilter) regressionFilter.value = '';
+
+            currentFilters = { status: '', testCaseId: '', agentId: '', regressionTestId: '' };
+            currentPage = 1;
+            loadTestLogs();
+        });
+    }
+
+    // Auto-apply filters on change
+    const statusFilter = document.getElementById('statusFilter');
+    if (statusFilter) {
+        statusFilter.addEventListener('change', (event) => {
+            currentFilters.status = event.target.value;
+            currentPage = 1;
+            loadTestLogs();
+        });
+    }
+
+    const testCaseFilter = document.getElementById('testCaseFilter');
+    if (testCaseFilter) {
+        testCaseFilter.addEventListener('change', async (event) => {
+            currentFilters.testCaseId = event.target.value;
+            currentPage = 1;
+            // Ensure test cases are loaded before loading logs
+            if (testCasesData.length === 0) {
+                await loadTestCases();
+            }
+            await loadTestLogs();
+        });
+    }
+
+    const agentFilter = document.getElementById('agentFilter');
+    if (agentFilter) {
+        agentFilter.addEventListener('change', (event) => {
+            currentFilters.agentId = event.target.value;
+            currentPage = 1;
+            loadTestLogs();
+        });
+    }
+
+    const regressionFilter = document.getElementById('regressionFilter');
+    if (regressionFilter) {
+        regressionFilter.addEventListener('change', (event) => {
+            currentFilters.regressionTestId = event.target.value;
+            currentPage = 1;
+            loadTestLogs();
+        });
+    }
 }
 
 async function loadTestLogs() {
@@ -416,28 +475,7 @@ async function viewLog(logId) {
     }
 }
 
-async function applyFilters() {
-    const status = document.getElementById('statusFilter').value;
-    const testCaseId = document.getElementById('testCaseFilter').value;
-    const agentId = document.getElementById('agentFilter').value;
-    const regressionId = document.getElementById('regressionFilter').value;
 
-    currentFilters = {
-        status: status || '',
-        testCaseId: testCaseId || '',
-        agentId: agentId || '',
-        regressionTestId: regressionId || ''
-    };
-
-    currentPage = 1;
-
-    // Ensure test cases are loaded before loading logs
-    if (testCasesData.length === 0) {
-        await loadTestCases();
-    }
-
-    await loadTestLogs();
-}
 
 async function deleteLog(logId) {
     if (!confirm('Are you sure you want to delete this test log? This action cannot be undone.')) {

--- a/templates/agent_detail.html
+++ b/templates/agent_detail.html
@@ -1,0 +1,419 @@
+{% extends "base.html" %}
+
+{% block page_title %}Agent Details - LLM Replay System{% endblock %}
+
+{% block extra_css %}
+<style>
+    /* Page Header */
+    .page-header {
+        margin-bottom: 2rem;
+    }
+
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
+
+    /* Action buttons in header */
+    .page-header #actionButtons {
+        margin-top: 0.5rem;
+    }
+
+    /* Card Styles */
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
+
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    .card-header {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 1rem 1.5rem;
+        border-radius: 0.75rem 0.75rem 0 0 !important;
+    }
+
+    .card-body {
+        padding: 1.5rem;
+    }
+
+    /* Button Styles */
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
+
+    .btn-outline-secondary {
+        color: var(--text-secondary);
+        border-color: var(--border-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-outline-secondary:hover {
+        background-color: var(--text-secondary);
+        border-color: var(--text-secondary);
+        transform: translateY(-1px);
+    }
+
+    .btn-success {
+        background-color: var(--success-color);
+        border-color: var(--success-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    .btn-outline-danger {
+        color: var(--danger-color);
+        border-color: var(--danger-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    /* Table Styles */
+    .info-table {
+        margin-bottom: 0;
+    }
+
+    .info-table td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+
+    .info-table td:first-child {
+        font-weight: 600;
+        color: var(--text-secondary);
+        width: 150px;
+        background-color: #f8fafc;
+    }
+
+    .info-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    /* Code Block Styles */
+    .code-block {
+        background-color: #f1f5f9;
+        border: 1px solid var(--border-color);
+        border-radius: 0.5rem;
+        padding: 1rem;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        max-height: 400px;
+        overflow-y: auto;
+        color: var(--text-primary);
+        white-space: pre-wrap;
+        word-wrap: break-word;
+    }
+
+    /* Loading State */
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
+
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
+
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    /* Error Message */
+    .error-message {
+        background-color: #fef2f2;
+        border: 1px solid #fecaca;
+        color: var(--danger-color);
+        padding: 1rem;
+        border-radius: 0.5rem;
+        margin: 1rem 0;
+    }
+
+    /* Responsive Improvements */
+    @media (max-width: 768px) {
+        .page-title {
+            font-size: 1.5rem;
+        }
+
+        .card-body {
+            padding: 1rem;
+        }
+
+        .info-table td:first-child {
+            width: 120px;
+            font-size: 0.875rem;
+        }
+
+        .btn-group {
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <!-- Header with Action Buttons -->
+    <div class="page-header d-flex justify-content-between align-items-start">
+        <div>
+            <h1 class="page-title">
+                <i class="fas fa-user-astronaut me-3"></i>Agent Details
+            </h1>
+            <p class="page-subtitle">Detailed view of agent configuration</p>
+        </div>
+        <div id="actionButtons" class="d-none">
+            <div class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-secondary" onclick="viewTestCases()">
+                    <i class="fas fa-list me-2"></i>View Test Cases
+                </button>
+                <button type="button" class="btn btn-primary" onclick="editAgent()">
+                    <i class="fas fa-edit me-2"></i>Edit Agent
+                </button>
+                <button type="button" class="btn btn-outline-danger" onclick="deleteAgent()">
+                    <i class="fas fa-trash me-2"></i>Delete Agent
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Loading Spinner -->
+    <div id="loadingSpinner" class="loading-state">
+        <div class="loading-spinner">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+            <span>Loading agent details...</span>
+        </div>
+    </div>
+
+    <!-- Error Message -->
+    <div id="errorMessage" class="error-message d-none">
+        <i class="fas fa-exclamation-triangle me-2"></i>
+        <span id="errorText"></span>
+    </div>
+
+    <!-- Agent Details Content -->
+    <div id="agentDetailsContent" class="d-none">
+        <!-- Content will be loaded here -->
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+    const agentId = '{{ agent_id }}';
+    let currentAgent = null;
+
+    document.addEventListener('DOMContentLoaded', function () {
+        loadAgentDetails();
+    });
+
+    async function loadAgentDetails() {
+        try {
+            const response = await fetch(`/v1/api/agents/${agentId}`);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            currentAgent = await response.json();
+            displayAgentDetails(currentAgent);
+
+            // Show action buttons and hide loading
+            document.getElementById('actionButtons').classList.remove('d-none');
+            document.getElementById('loadingSpinner').classList.add('d-none');
+            document.getElementById('agentDetailsContent').classList.remove('d-none');
+
+        } catch (error) {
+            console.error('Error loading agent details:', error);
+            document.getElementById('errorText').textContent = 'Failed to load agent details: ' + error.message;
+            document.getElementById('errorMessage').classList.remove('d-none');
+            document.getElementById('loadingSpinner').classList.add('d-none');
+        }
+    }
+
+    function displayAgentDetails(agent) {
+        const detailsHtml = `
+                <div class="row">
+                    <!-- Left Column -->
+                    <div class="col-md-6">
+                        <!-- Basic Information -->
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <i class="fas fa-info-circle me-2"></i>Basic Information
+                            </div>
+                            <div class="card-body p-0">
+                                <table class="table info-table mb-0">
+                                    <tr>
+                                        <td>Agent ID:</td>
+                                        <td><code>${escapeHtml(agent.id)}</code></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Name:</td>
+                                        <td><strong>${escapeHtml(agent.name)}</strong></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Description:</td>
+                                        <td>${escapeHtml(agent.description || 'No description provided')}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Created At:</td>
+                                        <td>${formatDate(agent.created_at)}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Updated At:</td>
+                                        <td>${formatDate(agent.updated_at)}</td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Right Column -->
+                    <div class="col-md-6">
+                        <!-- Default Configuration -->
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <i class="fas fa-cog me-2"></i>Default Configuration
+                            </div>
+                            <div class="card-body p-0">
+                                <table class="table info-table mb-0">
+                                    <tr>
+                                        <td>Model Name:</td>
+                                        <td>${agent.default_model_name ? `<code>${escapeHtml(agent.default_model_name)}</code>` : '<span class="text-muted">Not specified</span>'}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Model Settings:</td>
+                                        <td>${agent.default_model_settings !== null && agent.default_model_settings !== undefined ? `<pre class="bg-light p-2 rounded"><code>${escapeHtml(JSON.stringify(agent.default_model_settings, null, 2))}</code></pre>` : '<span class="text-muted">Not specified</span>'}</td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- System Prompt -->
+                ${agent.default_system_prompt ? `
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <i class="fas fa-terminal me-2"></i>Default System Prompt
+                        </div>
+                        <div class="card-body">
+                            <div class="code-block">${escapeHtml(agent.default_system_prompt)}</div>
+                        </div>
+                    </div>
+                ` : `
+                    <div class="card mb-4">
+                        <div class="card-header">
+                            <i class="fas fa-terminal me-2"></i>Default System Prompt
+                        </div>
+                        <div class="card-body">
+                            <p class="text-muted mb-0">No default system prompt configured</p>
+                        </div>
+                    </div>
+                `}
+            `;
+
+        document.getElementById('agentDetailsContent').innerHTML = detailsHtml;
+    }
+
+    function escapeHtml(text) {
+        if (text === null || text === undefined) return '';
+        const map = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        };
+        return text.toString().replace(/[&<>"']/g, function (m) { return map[m]; });
+    }
+
+    function formatDate(dateString) {
+        if (!dateString) return 'N/A';
+        const date = new Date(dateString);
+        return date.toLocaleString('en-US', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit'
+        });
+    }
+
+    function viewTestCases() {
+        if (currentAgent) {
+            window.open(`/test-cases?agentId=${currentAgent.id}`, '_blank');
+        } else {
+            window.open('/test-cases', '_blank');
+        }
+    }
+
+    function editAgent() {
+        if (currentAgent) {
+            // Redirect back to agents page with edit modal
+            window.location.href = `/agents?edit=${currentAgent.id}`;
+        }
+    }
+
+    async function deleteAgent() {
+        if (!currentAgent) return;
+
+        if (!confirm(`Are you sure you want to delete the agent "${currentAgent.name}"? This action cannot be undone and will also delete associated test cases.`)) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`/v1/api/agents/${currentAgent.id}`, {
+                method: 'DELETE'
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            alert('Agent deleted successfully!');
+            // Redirect back to agents page
+            window.location.href = '/agents';
+
+        } catch (error) {
+            console.error('Error deleting agent:', error);
+            alert('Error deleting agent: ' + error.message);
+        }
+    }
+</script>
+{% endblock %}

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -281,11 +281,11 @@
             <table class="table table-hover mb-0" id="agentsTable">
                 <thead>
                     <tr>
-                        <th style="width: 22%">Agent</th>
-                        <th style="width: 28%">Defaults</th>
-                        <th style="width: 18%">Updated</th>
-                        <th style="width: 12%">Status</th>
-                        <th style="width: 20%" class="text-end">Actions</th>
+                        <th style="width: 18%">Agent</th>
+                        <th style="width: 32%">Description</th>
+                        <th style="width: 26%">Defaults</th>
+                        <th style="width: 14%">Updated</th>
+                        <th style="width: 10%" class="text-end">Actions</th>
                     </tr>
                 </thead>
                 <tbody id="agentsList">

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -1,280 +1,179 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Agents - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
+{% block page_title %}Agents - LLM Replay System{% endblock %}
+
+{% block extra_css %}
+<style>
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
+
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
+
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
+
+    .btn-outline-primary {
+        color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    .btn-outline-primary:hover {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+    }
+
+    .badge {
+        font-weight: 500;
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+    }
+
+    .badge.bg-success {
+        background-color: var(--success-color) !important;
+    }
+
+    .badge.bg-secondary {
+        background-color: var(--secondary-color) !important;
+    }
+
+    .table-container {
+        background: var(--card-background);
+        border-radius: 0.75rem;
+        overflow: hidden;
+        border: 1px solid var(--border-color);
+    }
+
+    .table th {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 1rem;
+        font-size: 0.875rem;
+    }
+
+    .table td {
+        padding: 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+
+    .empty-state {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: var(--text-secondary);
+    }
+
+    .empty-state .empty-icon {
+        width: 4rem;
+        height: 4rem;
+        background-color: #f1f5f9;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 auto 1.5rem;
+    }
+
+    .empty-state .empty-icon i {
+        font-size: 1.5rem;
+        color: var(--text-muted);
+    }
+
+    .empty-state h3 {
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .empty-state p {
+        color: var(--text-secondary);
+        margin-bottom: 1.5rem;
+    }
+
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
+
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
+
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    .form-text {
+        color: var(--text-secondary);
+    }
+
+    .modal-content {
+        border-radius: 0.75rem;
+        border: 1px solid var(--border-color);
+    }
+
+    .modal-header,
+    .modal-footer {
+        border-color: var(--border-color);
+    }
+
+    @media (max-width: 768px) {
+        .page-title {
+            font-size: 1.5rem;
         }
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        .card-body {
+            padding: 1rem;
         }
 
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
-
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
+        .btn-group {
+            flex-direction: column;
             gap: 0.5rem;
         }
+    }
+</style>
+{% endblock %}
 
-        .navbar-brand i {
-            color: var(--primary-color);
-            font-size: 1.5rem;
-        }
-
-        .brand-text {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
-
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
-
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
-
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
-
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
-
-        .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
-
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
-
-        .card:hover {
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        }
-
-        .btn-primary {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            padding: 0.625rem 1.25rem;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-primary:hover {
-            background-color: var(--primary-hover);
-            border-color: var(--primary-hover);
-            transform: translateY(-1px);
-        }
-
-        .btn-outline-primary {
-            color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
-
-        .btn-outline-primary:hover {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-        }
-
-        .badge {
-            font-weight: 500;
-            padding: 0.375rem 0.75rem;
-            border-radius: 0.375rem;
-            font-size: 0.75rem;
-        }
-
-        .badge.bg-success {
-            background-color: var(--success-color) !important;
-        }
-
-        .badge.bg-secondary {
-            background-color: var(--secondary-color) !important;
-        }
-
-        .table-container {
-            background: var(--card-background);
-            border-radius: 0.75rem;
-            overflow: hidden;
-            border: 1px solid var(--border-color);
-        }
-
-        .table th {
-            background-color: #f8fafc;
-            border-bottom: 1px solid var(--border-color);
-            font-weight: 600;
-            color: var(--text-primary);
-            padding: 1rem;
-            font-size: 0.875rem;
-        }
-
-        .table td {
-            padding: 1rem;
-            border-bottom: 1px solid #f1f5f9;
-            vertical-align: middle;
-        }
-
-        .empty-state {
-            text-align: center;
-            padding: 4rem 2rem;
-            color: var(--text-secondary);
-        }
-
-        .empty-state .empty-icon {
-            width: 4rem;
-            height: 4rem;
-            background-color: #f1f5f9;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 0 auto 1.5rem;
-        }
-
-        .empty-state .empty-icon i {
-            font-size: 1.5rem;
-            color: var(--text-muted);
-        }
-
-        .empty-state h3 {
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .empty-state p {
-            color: var(--text-secondary);
-            margin-bottom: 1.5rem;
-        }
-
-        .loading-state {
-            text-align: center;
-            padding: 3rem 2rem;
-        }
-
-        .loading-spinner {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            color: var(--primary-color);
-        }
-
-        .loading-spinner .spinner-border {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        .form-text {
-            color: var(--text-secondary);
-        }
-
-        .modal-content {
-            border-radius: 0.75rem;
-            border: 1px solid var(--border-color);
-        }
-
-        .modal-header,
-        .modal-footer {
-            border-color: var(--border-color);
-        }
-
-        @media (max-width: 768px) {
-            .page-title {
-                font-size: 1.5rem;
-            }
-
-            .card-body {
-                padding: 1rem;
-            }
-
-            .btn-group {
-                flex-direction: column;
-                gap: 0.5rem;
-            }
-        }
-    </style>
-</head>
-
-<body>
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link active" href="/agents">Agents</a>
-                <a class="nav-link" href="/test-cases">Test Cases</a>
-                <a class="nav-link" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
             <div class="mb-3 mb-lg-0">
@@ -424,9 +323,8 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script src="/static/js/agents.js?v={{ static_asset_version }}"></script>
-</body>
-
-</html>
+{% endblock %}

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -284,7 +284,7 @@
                         <th style="width: 18%">Agent</th>
                         <th style="width: 32%">Description</th>
                         <th style="width: 26%">Defaults</th>
-                        <th style="width: 14%">Updated</th>
+                        <th style="width: 14%">Created</th>
                         <th style="width: 10%" class="text-end">Actions</th>
                     </tr>
                 </thead>

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -49,6 +49,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -242,7 +260,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link active" href="/agents">Agents</a>

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -262,9 +262,9 @@
                 </h1>
                 <p class="page-subtitle mb-0">Manage reusable model configurations and ownership for your test cases</p>
             </div>
-            <div class="d-flex align-items-center gap-3">
+            <div class="d-flex align-items-center gap-2">
                 <button class="btn btn-outline-primary" id="refreshAgentsBtn">
-                    <i class="fas fa-rotate me-2"></i>Refresh
+                    <i class="fas fa-refresh me-2"></i>Refresh
                 </button>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createAgentModal" id="createAgentBtn">
                     <i class="fas fa-plus me-2"></i>Create Agent

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -263,10 +263,6 @@
                 <p class="page-subtitle mb-0">Manage reusable model configurations and ownership for your test cases</p>
             </div>
             <div class="d-flex align-items-center gap-3">
-                <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" role="switch" id="includeDeletedToggle">
-                    <label class="form-check-label" for="includeDeletedToggle">Show archived agents</label>
-                </div>
                 <button class="btn btn-outline-primary" id="refreshAgentsBtn">
                     <i class="fas fa-rotate me-2"></i>Refresh
                 </button>

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agents - LLM Replay System</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --primary-color: #2563eb;
+            --primary-hover: #1d4ed8;
+            --secondary-color: #64748b;
+            --success-color: #059669;
+            --warning-color: #d97706;
+            --danger-color: #dc2626;
+            --background-color: #f8fafc;
+            --card-background: #ffffff;
+            --border-color: #e2e8f0;
+            --text-primary: #1e293b;
+            --text-secondary: #64748b;
+            --text-muted: #94a3b8;
+        }
+
+        body {
+            background-color: var(--background-color);
+            color: var(--text-primary);
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        .navbar {
+            background: var(--card-background) !important;
+            border-bottom: 1px solid var(--border-color);
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            padding: 1rem 0;
+        }
+
+        .navbar-brand {
+            font-weight: 700;
+            color: var(--text-primary) !important;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .navbar-brand i {
+            color: var(--primary-color);
+            font-size: 1.5rem;
+        }
+
+        .navbar-nav .nav-link {
+            font-weight: 500;
+            color: var(--text-secondary) !important;
+            padding: 0.5rem 1rem !important;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease;
+        }
+
+        .navbar-nav .nav-link:hover {
+            color: var(--primary-color) !important;
+            background-color: rgba(37, 99, 235, 0.1);
+        }
+
+        .navbar-nav .nav-link.active {
+            color: var(--primary-color) !important;
+            background-color: rgba(37, 99, 235, 0.1);
+            font-weight: 600;
+        }
+
+        .page-title {
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .page-subtitle {
+            color: var(--text-secondary);
+            font-size: 1rem;
+        }
+
+        .card {
+            background: var(--card-background);
+            border: 1px solid var(--border-color);
+            border-radius: 0.75rem;
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            transition: all 0.2s ease;
+        }
+
+        .card:hover {
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        }
+
+        .btn-primary {
+            background-color: var(--primary-color);
+            border-color: var(--primary-color);
+            font-weight: 500;
+            padding: 0.625rem 1.25rem;
+            border-radius: 0.5rem;
+            transition: all 0.2s ease;
+        }
+
+        .btn-primary:hover {
+            background-color: var(--primary-hover);
+            border-color: var(--primary-hover);
+            transform: translateY(-1px);
+        }
+
+        .btn-outline-primary {
+            color: var(--primary-color);
+            border-color: var(--primary-color);
+            font-weight: 500;
+            border-radius: 0.5rem;
+        }
+
+        .btn-outline-primary:hover {
+            background-color: var(--primary-color);
+            border-color: var(--primary-color);
+        }
+
+        .badge {
+            font-weight: 500;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.75rem;
+        }
+
+        .badge.bg-success {
+            background-color: var(--success-color) !important;
+        }
+
+        .badge.bg-secondary {
+            background-color: var(--secondary-color) !important;
+        }
+
+        .table-container {
+            background: var(--card-background);
+            border-radius: 0.75rem;
+            overflow: hidden;
+            border: 1px solid var(--border-color);
+        }
+
+        .table th {
+            background-color: #f8fafc;
+            border-bottom: 1px solid var(--border-color);
+            font-weight: 600;
+            color: var(--text-primary);
+            padding: 1rem;
+            font-size: 0.875rem;
+        }
+
+        .table td {
+            padding: 1rem;
+            border-bottom: 1px solid #f1f5f9;
+            vertical-align: middle;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 4rem 2rem;
+            color: var(--text-secondary);
+        }
+
+        .empty-state .empty-icon {
+            width: 4rem;
+            height: 4rem;
+            background-color: #f1f5f9;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 1.5rem;
+        }
+
+        .empty-state .empty-icon i {
+            font-size: 1.5rem;
+            color: var(--text-muted);
+        }
+
+        .empty-state h3 {
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .empty-state p {
+            color: var(--text-secondary);
+            margin-bottom: 1.5rem;
+        }
+
+        .loading-state {
+            text-align: center;
+            padding: 3rem 2rem;
+        }
+
+        .loading-spinner {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+            color: var(--primary-color);
+        }
+
+        .loading-spinner .spinner-border {
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+
+        .form-text {
+            color: var(--text-secondary);
+        }
+
+        .modal-content {
+            border-radius: 0.75rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .modal-header,
+        .modal-footer {
+            border-color: var(--border-color);
+        }
+
+        @media (max-width: 768px) {
+            .page-title {
+                font-size: 1.5rem;
+            }
+
+            .card-body {
+                padding: 1rem;
+            }
+
+            .btn-group {
+                flex-direction: column;
+                gap: 0.5rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <i class="fas fa-robot"></i>
+                <span>LLM Replay System</span>
+            </a>
+            <div class="navbar-nav ms-auto">
+                <a class="nav-link active" href="/agents">Agents</a>
+                <a class="nav-link" href="/test-cases">Test Cases</a>
+                <a class="nav-link" href="/regression-tests">Regression Tests</a>
+                <a class="nav-link" href="/test-execution">Execute Tests</a>
+                <a class="nav-link" href="/test-logs">Test Logs</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container py-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
+            <div class="mb-3 mb-lg-0">
+                <h1 class="page-title">
+                    <i class="fas fa-user-astronaut me-3"></i>Agents
+                </h1>
+                <p class="page-subtitle mb-0">Manage reusable model configurations and ownership for your test cases</p>
+            </div>
+            <div class="d-flex align-items-center gap-3">
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" role="switch" id="includeDeletedToggle">
+                    <label class="form-check-label" for="includeDeletedToggle">Show archived agents</label>
+                </div>
+                <button class="btn btn-outline-primary" id="refreshAgentsBtn">
+                    <i class="fas fa-rotate me-2"></i>Refresh
+                </button>
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createAgentModal" id="createAgentBtn">
+                    <i class="fas fa-plus me-2"></i>Create Agent
+                </button>
+            </div>
+        </div>
+
+        <div id="agentHelp" class="alert alert-info d-none" role="alert">
+            <i class="fas fa-circle-info me-2"></i>
+            <span>Agents capture default model parameters for reuse during regression runs. Create at least one agent before adding new test cases.</span>
+        </div>
+
+        <div class="table-container">
+            <table class="table table-hover mb-0" id="agentsTable">
+                <thead>
+                    <tr>
+                        <th style="width: 22%">Agent</th>
+                        <th style="width: 28%">Defaults</th>
+                        <th style="width: 18%">Updated</th>
+                        <th style="width: 12%">Status</th>
+                        <th style="width: 20%" class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="agentsList">
+                    <!-- Agents will be rendered here -->
+                </tbody>
+            </table>
+        </div>
+
+        <div id="loadingSpinner" class="loading-state d-none">
+            <div class="loading-spinner">
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                <span>Loading agents...</span>
+            </div>
+        </div>
+
+        <div id="emptyState" class="empty-state d-none">
+            <div class="empty-icon">
+                <i class="fas fa-users-slash"></i>
+            </div>
+            <h3>No agents configured</h3>
+            <p>Agents keep your regression defaults consistent. Create your first agent to get started.</p>
+            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createAgentModal">
+                <i class="fas fa-plus me-2"></i>Create Agent
+            </button>
+        </div>
+    </div>
+
+    <!-- Create Agent Modal -->
+    <div class="modal fade" id="createAgentModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Create Agent</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="createAgentAlert"></div>
+                    <form id="createAgentForm">
+                        <div class="mb-3">
+                            <label for="createAgentName" class="form-label">Name *</label>
+                            <input type="text" class="form-control" id="createAgentName" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="createAgentDescription" class="form-label">Description</label>
+                            <textarea class="form-control" id="createAgentDescription" rows="3" placeholder="Describe the scenarios this agent covers"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="createAgentModelName" class="form-label">Default Model Name *</label>
+                            <input type="text" class="form-control" id="createAgentModelName" placeholder="e.g. gpt-4o" required>
+                            <div class="form-text">Used as the baseline model during regression runs. You can override it per run.</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="createAgentSystemPrompt" class="form-label">Default System Prompt *</label>
+                            <textarea class="form-control" id="createAgentSystemPrompt" rows="4" placeholder="Provide the default system instructions" required></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="createAgentModelSettings" class="form-label">Default Model Settings (JSON)</label>
+                            <textarea class="form-control" id="createAgentModelSettings" rows="5" placeholder='{"temperature": 0.2, "max_tokens": 4096}'></textarea>
+                            <div class="form-text">Optional JSON blob applied to all regression executions. Leave blank to use per test case settings.</div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="confirmCreateAgent">
+                        <i class="fas fa-save me-2"></i>Create Agent
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Edit Agent Modal -->
+    <div class="modal fade" id="editAgentModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit Agent</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="editAgentAlert"></div>
+                    <form id="editAgentForm">
+                        <input type="hidden" id="editAgentId">
+                        <div class="mb-3">
+                            <label for="editAgentName" class="form-label">Name *</label>
+                            <input type="text" class="form-control" id="editAgentName" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAgentDescription" class="form-label">Description</label>
+                            <textarea class="form-control" id="editAgentDescription" rows="3"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAgentModelName" class="form-label">Default Model Name *</label>
+                            <input type="text" class="form-control" id="editAgentModelName" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAgentSystemPrompt" class="form-label">Default System Prompt *</label>
+                            <textarea class="form-control" id="editAgentSystemPrompt" rows="4" required></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editAgentModelSettings" class="form-label">Default Model Settings (JSON)</label>
+                            <textarea class="form-control" id="editAgentModelSettings" rows="5"></textarea>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="confirmUpdateAgent">
+                        <i class="fas fa-save me-2"></i>Save Changes
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/js/agents.js?v={{ static_asset_version }}"></script>
+</body>
+
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,9 @@
         </div>
     </nav>
 
-    {% block content %}{% endblock %}
+        <div id="toast-root"></div>
+
+{% block content %}{% endblock %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     {% block extra_scripts %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block page_title %}LLM Replay System{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="/static/css/main.css?v={{ static_asset_version }}" rel="stylesheet">
+    {% block extra_css %}{% endblock %}
+</head>
+
+<body>
+    {% set current_page = active_page | default('') %}
+    <nav class="navbar navbar-expand-lg">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <i class="fas fa-robot"></i>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
+            </a>
+            <div class="navbar-nav ms-auto">
+                <a class="nav-link {% if current_page == 'agents' %}active{% endif %}" href="/agents">Agents</a>
+                <a class="nav-link {% if current_page == 'test-cases' %}active{% endif %}" href="/test-cases">Test Cases</a>
+                <a class="nav-link {% if current_page == 'regression-tests' %}active{% endif %}" href="/regression-tests">Regression Tests</a>
+                <a class="nav-link {% if current_page == 'test-execution' %}active{% endif %}" href="/test-execution">Execute Tests</a>
+                <a class="nav-link {% if current_page == 'test-logs' %}active{% endif %}" href="/test-logs">Test Logs</a>
+            </div>
+        </div>
+    </nav>
+
+    {% block content %}{% endblock %}
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_scripts %}{% endblock %}
+</body>
+
+</html>

--- a/templates/regression_test_detail.html
+++ b/templates/regression_test_detail.html
@@ -49,6 +49,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -179,7 +197,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="/agents">Agents</a>

--- a/templates/regression_test_detail.html
+++ b/templates/regression_test_detail.html
@@ -1,217 +1,116 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Regression Test Details - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
-        }
+{% block page_title %}Regression Test Details - LLM Replay System{% endblock %}
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
+{% block extra_css %}
+<style>
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
 
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
 
-        .navbar-brand i {
-            color: var(--primary-color);
+    .card-header {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+    }
+
+    .badge {
+        font-weight: 500;
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+    }
+
+    .badge.bg-success {
+        background-color: var(--success-color) !important;
+    }
+
+    .badge.bg-warning {
+        background-color: var(--warning-color) !important;
+    }
+
+    .badge.bg-danger {
+        background-color: var(--danger-color) !important;
+    }
+
+    .badge.bg-secondary {
+        background-color: var(--secondary-color) !important;
+    }
+
+    .info-table td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+
+    .info-table td:first-child {
+        font-weight: 600;
+        color: var(--text-secondary);
+        width: 160px;
+        background-color: #f8fafc;
+    }
+
+    .info-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
+
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
+
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    .llm-response {
+        background-color: #f1f5f9;
+        border: 1px solid var(--border-color);
+        border-radius: 0.5rem;
+        padding: 1rem;
+        font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+        font-size: 0.875rem;
+        max-height: 320px;
+        overflow-y: auto;
+    }
+
+    @media (max-width: 768px) {
+        .page-title {
             font-size: 1.5rem;
         }
 
-        .brand-text {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
-
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
-
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
-
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
-
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
-
-        .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
-
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
-
-        .card-header {
-            background-color: #f8fafc;
-            border-bottom: 1px solid var(--border-color);
-            font-weight: 600;
-        }
-
-        .badge {
-            font-weight: 500;
-            padding: 0.375rem 0.75rem;
-            border-radius: 0.375rem;
-            font-size: 0.75rem;
-        }
-
-        .badge.bg-success {
-            background-color: var(--success-color) !important;
-        }
-
-        .badge.bg-warning {
-            background-color: var(--warning-color) !important;
-        }
-
-        .badge.bg-danger {
-            background-color: var(--danger-color) !important;
-        }
-
-        .badge.bg-secondary {
-            background-color: var(--secondary-color) !important;
-        }
-
-        .info-table td {
-            padding: 0.75rem 1rem;
-            border-bottom: 1px solid #f1f5f9;
-            vertical-align: middle;
-        }
-
-        .info-table td:first-child {
-            font-weight: 600;
-            color: var(--text-secondary);
-            width: 160px;
-            background-color: #f8fafc;
-        }
-
-        .info-table tr:last-child td {
-            border-bottom: none;
-        }
-
-        .loading-state {
-            text-align: center;
-            padding: 3rem 2rem;
-        }
-
-        .loading-spinner {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            color: var(--primary-color);
-        }
-
-        .loading-spinner .spinner-border {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        .llm-response {
-            background-color: #f1f5f9;
-            border: 1px solid var(--border-color);
-            border-radius: 0.5rem;
+        .card-body {
             padding: 1rem;
-            font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
-            font-size: 0.875rem;
-            max-height: 320px;
-            overflow-y: auto;
         }
+    }
+</style>
+{% endblock %}
 
-        @media (max-width: 768px) {
-            .page-title {
-                font-size: 1.5rem;
-            }
-
-            .card-body {
-                padding: 1rem;
-            }
-        }
-    </style>
-</head>
-
-<body>
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/agents">Agents</a>
-                <a class="nav-link" href="/test-cases">Test Cases</a>
-                <a class="nav-link active" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
             <div class="mb-3 mb-lg-0">
@@ -352,12 +251,11 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script>
-        const regressionId = '{{ regression_test_id }}';
-    </script>
-    <script src="/static/js/regression-test-detail.js?v={{ static_asset_version }}"></script>
-</body>
-
-</html>
+            const regressionId = '{{ regression_test_id }}';
+        </script>
+        <script src="/static/js/regression-test-detail.js?v={{ static_asset_version }}"></script>
+{% endblock %}

--- a/templates/regression_test_detail.html
+++ b/templates/regression_test_detail.html
@@ -53,6 +53,40 @@
         background-color: var(--secondary-color) !important;
     }
 
+    .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.875rem;
+        color: #fff;
+        box-shadow: 0 10px 20px -12px rgba(15, 23, 42, 0.45);
+        transition: transform 0.2s ease;
+    }
+
+    .status-pill i {
+        font-size: 0.9rem;
+    }
+
+    .status-pill.status-success {
+        background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    }
+
+    .status-pill.status-warning {
+        background: linear-gradient(135deg, #facc15 0%, #eab308 100%);
+        color: #1f2937;
+    }
+
+    .status-pill.status-danger {
+        background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+    }
+
+    .status-pill.status-secondary {
+        background: linear-gradient(135deg, #94a3b8 0%, #64748b 100%);
+    }
+
     .info-table td {
         padding: 0.75rem 1rem;
         border-bottom: 1px solid #f1f5f9;
@@ -149,7 +183,7 @@
                     <div class="card h-100">
                         <div class="card-header d-flex justify-content-between align-items-center">
                             <span>Execution Summary</span>
-                            <span id="statusBadge" class="badge bg-secondary"></span>
+                            <span id="statusBadge"></span>
                         </div>
                         <div class="card-body p-0">
                             <table class="table mb-0 info-table">
@@ -214,41 +248,6 @@
                 <span id="errorMessageText"></span>
             </div>
 
-            <div class="card">
-                <div class="card-header d-flex justify-content-between align-items-center">
-                    <span>Latest Logs</span>
-                    <div class="d-flex gap-2">
-                        <button class="btn btn-outline-secondary btn-sm" id="refreshLogsBtn">
-                            <i class="fas fa-rotate me-1"></i>Refresh Logs
-                        </button>
-                        <a class="btn btn-outline-primary btn-sm" id="viewAllLogsBtn" target="_blank">
-                            <i class="fas fa-up-right-from-square me-1"></i>Open in Logs Page
-                        </a>
-                    </div>
-                </div>
-                <div class="card-body">
-                    <div id="logsEmptyState" class="text-center text-muted d-none">
-                        <i class="fas fa-inbox fa-2x mb-2"></i>
-                        <p class="mb-0">No logs have been recorded for this regression yet.</p>
-                    </div>
-                    <div class="table-responsive">
-                        <table class="table table-hover mb-0" id="logsTable">
-                            <thead>
-                                <tr>
-                                    <th style="width: 28%">Test Case</th>
-                                    <th style="width: 14%">Status</th>
-                                    <th style="width: 18%">Model</th>
-                                    <th style="width: 18%">Response Time</th>
-                                    <th style="width: 22%">Timestamp</th>
-                                </tr>
-                            </thead>
-                            <tbody id="logsList">
-                                <!-- Logs will be injected here -->
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 {% endblock %}

--- a/templates/regression_test_detail.html
+++ b/templates/regression_test_detail.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Regression Test Details - LLM Replay System</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --primary-color: #2563eb;
+            --primary-hover: #1d4ed8;
+            --secondary-color: #64748b;
+            --success-color: #059669;
+            --warning-color: #d97706;
+            --danger-color: #dc2626;
+            --background-color: #f8fafc;
+            --card-background: #ffffff;
+            --border-color: #e2e8f0;
+            --text-primary: #1e293b;
+            --text-secondary: #64748b;
+            --text-muted: #94a3b8;
+        }
+
+        body {
+            background-color: var(--background-color);
+            color: var(--text-primary);
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        .navbar {
+            background: var(--card-background) !important;
+            border-bottom: 1px solid var(--border-color);
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            padding: 1rem 0;
+        }
+
+        .navbar-brand {
+            font-weight: 700;
+            color: var(--text-primary) !important;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .navbar-brand i {
+            color: var(--primary-color);
+            font-size: 1.5rem;
+        }
+
+        .navbar-nav .nav-link {
+            font-weight: 500;
+            color: var(--text-secondary) !important;
+            padding: 0.5rem 1rem !important;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease;
+        }
+
+        .navbar-nav .nav-link:hover {
+            color: var(--primary-color) !important;
+            background-color: rgba(37, 99, 235, 0.1);
+        }
+
+        .navbar-nav .nav-link.active {
+            color: var(--primary-color) !important;
+            background-color: rgba(37, 99, 235, 0.1);
+            font-weight: 600;
+        }
+
+        .page-title {
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .page-subtitle {
+            color: var(--text-secondary);
+            font-size: 1rem;
+        }
+
+        .card {
+            background: var(--card-background);
+            border: 1px solid var(--border-color);
+            border-radius: 0.75rem;
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            transition: all 0.2s ease;
+        }
+
+        .card-header {
+            background-color: #f8fafc;
+            border-bottom: 1px solid var(--border-color);
+            font-weight: 600;
+        }
+
+        .badge {
+            font-weight: 500;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.75rem;
+        }
+
+        .badge.bg-success {
+            background-color: var(--success-color) !important;
+        }
+
+        .badge.bg-warning {
+            background-color: var(--warning-color) !important;
+        }
+
+        .badge.bg-danger {
+            background-color: var(--danger-color) !important;
+        }
+
+        .badge.bg-secondary {
+            background-color: var(--secondary-color) !important;
+        }
+
+        .info-table td {
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid #f1f5f9;
+            vertical-align: middle;
+        }
+
+        .info-table td:first-child {
+            font-weight: 600;
+            color: var(--text-secondary);
+            width: 160px;
+            background-color: #f8fafc;
+        }
+
+        .info-table tr:last-child td {
+            border-bottom: none;
+        }
+
+        .loading-state {
+            text-align: center;
+            padding: 3rem 2rem;
+        }
+
+        .loading-spinner {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+            color: var(--primary-color);
+        }
+
+        .loading-spinner .spinner-border {
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+
+        .llm-response {
+            background-color: #f1f5f9;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+            font-size: 0.875rem;
+            max-height: 320px;
+            overflow-y: auto;
+        }
+
+        @media (max-width: 768px) {
+            .page-title {
+                font-size: 1.5rem;
+            }
+
+            .card-body {
+                padding: 1rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <i class="fas fa-robot"></i>
+                <span>LLM Replay System</span>
+            </a>
+            <div class="navbar-nav ms-auto">
+                <a class="nav-link" href="/agents">Agents</a>
+                <a class="nav-link" href="/test-cases">Test Cases</a>
+                <a class="nav-link active" href="/regression-tests">Regression Tests</a>
+                <a class="nav-link" href="/test-execution">Execute Tests</a>
+                <a class="nav-link" href="/test-logs">Test Logs</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container py-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
+            <div class="mb-3 mb-lg-0">
+                <h1 class="page-title">
+                    <i class="fas fa-vial-circle-check me-3"></i>Regression Test Details
+                </h1>
+                <p class="page-subtitle mb-0">Inspect overrides, execution stats, and generated logs</p>
+            </div>
+            <div class="d-flex gap-2">
+                <button class="btn btn-outline-primary" id="refreshDetailBtn">
+                    <i class="fas fa-rotate me-2"></i>Refresh
+                </button>
+                <a class="btn btn-primary" id="openLogsBtn" target="_blank">
+                    <i class="fas fa-scroll me-2"></i>Open Logs
+                </a>
+            </div>
+        </div>
+
+        <div id="loadingSpinner" class="loading-state">
+            <div class="loading-spinner">
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                <span>Loading regression test details...</span>
+            </div>
+        </div>
+
+        <div id="errorMessage" class="alert alert-danger d-none" role="alert">
+            <i class="fas fa-circle-exclamation me-2"></i>
+            <span id="errorText"></span>
+        </div>
+
+        <div id="regressionContent" class="d-none">
+            <div class="row g-4 mb-4">
+                <div class="col-lg-6">
+                    <div class="card h-100">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <span>Execution Summary</span>
+                            <span id="statusBadge" class="badge bg-secondary"></span>
+                        </div>
+                        <div class="card-body p-0">
+                            <table class="table mb-0 info-table">
+                                <tbody>
+                                    <tr>
+                                        <td>Regression ID</td>
+                                        <td><code id="regressionId"></code></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Agent</td>
+                                        <td>
+                                            <div class="d-flex align-items-center gap-2">
+                                                <i class="fas fa-user-astronaut text-primary"></i>
+                                                <span id="agentName"></span>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>Started</td>
+                                        <td id="startedAt"></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Completed</td>
+                                        <td id="completedAt"></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Totals</td>
+                                        <td>
+                                            <span class="badge bg-primary me-2">Total: <span id="totalCount"></span></span>
+                                            <span class="badge bg-success me-2">Passed: <span id="successCount"></span></span>
+                                            <span class="badge bg-danger">Failed: <span id="failedCount"></span></span>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-6">
+                    <div class="card h-100">
+                        <div class="card-header">Override Parameters</div>
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <h6 class="text-uppercase text-muted small mb-1">Model Name</h6>
+                                <div class="fw-semibold" id="overrideModel"></div>
+                            </div>
+                            <div class="mb-3">
+                                <h6 class="text-uppercase text-muted small mb-1">System Prompt</h6>
+                                <div class="llm-response" id="overridePrompt"></div>
+                            </div>
+                            <div>
+                                <h6 class="text-uppercase text-muted small mb-1">Model Settings JSON</h6>
+                                <div class="llm-response" id="overrideSettings"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div id="errorSection" class="alert alert-danger d-none" role="alert">
+                <i class="fas fa-triangle-exclamation me-2"></i>
+                <span id="errorMessageText"></span>
+            </div>
+
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>Latest Logs</span>
+                    <div class="d-flex gap-2">
+                        <button class="btn btn-outline-secondary btn-sm" id="refreshLogsBtn">
+                            <i class="fas fa-rotate me-1"></i>Refresh Logs
+                        </button>
+                        <a class="btn btn-outline-primary btn-sm" id="viewAllLogsBtn" target="_blank">
+                            <i class="fas fa-up-right-from-square me-1"></i>Open in Logs Page
+                        </a>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div id="logsEmptyState" class="text-center text-muted d-none">
+                        <i class="fas fa-inbox fa-2x mb-2"></i>
+                        <p class="mb-0">No logs have been recorded for this regression yet.</p>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0" id="logsTable">
+                            <thead>
+                                <tr>
+                                    <th style="width: 28%">Test Case</th>
+                                    <th style="width: 14%">Status</th>
+                                    <th style="width: 18%">Model</th>
+                                    <th style="width: 18%">Response Time</th>
+                                    <th style="width: 22%">Timestamp</th>
+                                </tr>
+                            </thead>
+                            <tbody id="logsList">
+                                <!-- Logs will be injected here -->
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        const regressionId = '{{ regression_test_id }}';
+    </script>
+    <script src="/static/js/regression-test-detail.js?v={{ static_asset_version }}"></script>
+</body>
+
+</html>

--- a/templates/regression_tests.html
+++ b/templates/regression_tests.html
@@ -49,6 +49,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -246,7 +264,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="/agents">Agents</a>

--- a/templates/regression_tests.html
+++ b/templates/regression_tests.html
@@ -219,11 +219,6 @@
             </div>
         </div>
 
-        <div id="regressionNotice" class="alert alert-info d-none" role="alert">
-            <i class="fas fa-circle-info me-2"></i>
-            <span>Running regressions apply the agent's defaults to every case. Override values below if you need a custom run.</span>
-        </div>
-
         <div class="table-container">
             <table class="table table-hover mb-0" id="regressionTestsTable">
                 <thead>

--- a/templates/regression_tests.html
+++ b/templates/regression_tests.html
@@ -237,16 +237,6 @@
             .card-body {
                 padding: 1rem;
             }
-
-            .filter-group {
-                flex-direction: column;
-                align-items: stretch !important;
-            }
-
-            .filter-group > * {
-                width: 100% !important;
-                margin-bottom: 0.75rem;
-            }
         }
     </style>
 </head>
@@ -271,14 +261,14 @@
     <div class="container py-4">
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
             <div class="mb-3 mb-lg-0">
-                <h1 class="page-title">
+                <h1 class="page-title mb-1">
                     <i class="fas fa-repeat me-3"></i>Regression Tests
                 </h1>
                 <p class="page-subtitle mb-0">Run every test case for an agent with consistent overrides</p>
             </div>
-            <div class="d-flex align-items-center gap-3">
+            <div class="d-flex align-items-center gap-2">
                 <button class="btn btn-outline-primary" id="refreshRegressionsBtn">
-                    <i class="fas fa-rotate me-2"></i>Refresh
+                    <i class="fas fa-refresh me-2"></i>Refresh
                 </button>
                 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#startRegressionModal" id="startRegressionBtn">
                     <i class="fas fa-rocket me-2"></i>Start Regression
@@ -288,34 +278,23 @@
 
         <div class="card mb-4">
             <div class="card-body py-3">
-                <div class="d-flex flex-wrap filter-group align-items-center gap-3">
-                    <div class="d-flex flex-column">
-                        <label class="text-muted fw-medium mb-1" for="agentFilter">Agent</label>
-                        <select class="form-select form-select-sm" id="agentFilter" style="min-width: 220px;">
-                            <option value="">All agents</option>
-                        </select>
-                    </div>
-                    <div class="d-flex flex-column">
-                        <label class="text-muted fw-medium mb-1" for="statusFilter">Status</label>
-                        <select class="form-select form-select-sm" id="statusFilter" style="min-width: 180px;">
-                            <option value="">All statuses</option>
-                            <option value="pending">Pending</option>
-                            <option value="running">Running</option>
-                            <option value="completed">Completed</option>
-                            <option value="failed">Failed</option>
-                        </select>
-                    </div>
-                    <div class="d-flex flex-column ms-auto">
-                        <label class="text-muted fw-medium mb-1">Actions</label>
-                        <div class="d-flex gap-2">
-                            <button class="btn btn-outline-secondary btn-sm" id="clearFiltersBtn">
-                                <i class="fas fa-eraser me-1"></i>Clear
-                            </button>
-                            <button class="btn btn-primary btn-sm" id="applyFiltersBtn">
-                                <i class="fas fa-filter me-1"></i>Apply
-                            </button>
-                        </div>
-                    </div>
+                <div class="d-flex flex-wrap align-items-center gap-3">
+                    <span class="text-muted fw-medium me-2 d-flex align-items-center">
+                        <i class="fas fa-filter me-2"></i>Filters:
+                    </span>
+                    <select class="form-select form-select-sm" id="agentFilter" style="width: 220px; flex: 0 0 auto;">
+                        <option value="">All agents</option>
+                    </select>
+                    <select class="form-select form-select-sm" id="statusFilter" style="width: 180px; flex: 0 0 auto;">
+                        <option value="">All statuses</option>
+                        <option value="pending">Pending</option>
+                        <option value="running">Running</option>
+                        <option value="completed">Completed</option>
+                        <option value="failed">Failed</option>
+                    </select>
+                    <button class="btn btn-outline-secondary btn-sm ms-auto" id="clearFiltersBtn">
+                        <i class="fas fa-eraser me-1"></i>Clear
+                    </button>
                 </div>
             </div>
         </div>

--- a/templates/regression_tests.html
+++ b/templates/regression_tests.html
@@ -1,284 +1,183 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Regression Tests - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
-        }
+{% block page_title %}Regression Tests - LLM Replay System{% endblock %}
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
+{% block extra_css %}
+<style>
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
 
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
 
-        .navbar-brand i {
-            color: var(--primary-color);
-            font-size: 1.5rem;
-        }
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
 
-        .brand-text {
-            display: flex;
-            flex-direction: column;
-        }
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
 
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
 
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
+    .btn-outline-primary {
+        color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
 
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
+    .btn-outline-primary:hover {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+    }
 
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
+    .table-container {
+        background: var(--card-background);
+        border-radius: 0.75rem;
+        overflow: hidden;
+        border: 1px solid var(--border-color);
+    }
 
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
+    .table th {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 1rem;
+        font-size: 0.875rem;
+    }
 
+    .table td {
+        padding: 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+
+    .badge {
+        font-weight: 500;
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+    }
+
+    .badge.bg-success {
+        background-color: var(--success-color) !important;
+    }
+
+    .badge.bg-warning {
+        background-color: var(--warning-color) !important;
+    }
+
+    .badge.bg-danger {
+        background-color: var(--danger-color) !important;
+    }
+
+    .badge.bg-secondary {
+        background-color: var(--secondary-color) !important;
+    }
+
+    .empty-state {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: var(--text-secondary);
+    }
+
+    .empty-state .empty-icon {
+        width: 4rem;
+        height: 4rem;
+        background-color: #f1f5f9;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 auto 1.5rem;
+    }
+
+    .empty-state .empty-icon i {
+        font-size: 1.5rem;
+        color: var(--text-muted);
+    }
+
+    .empty-state h3 {
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .empty-state p {
+        color: var(--text-secondary);
+        margin-bottom: 1.5rem;
+    }
+
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
+
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
+
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    .form-select,
+    .form-control {
+        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        padding: 0.625rem 0.75rem;
+        transition: all 0.2s ease;
+        background-color: var(--card-background);
+    }
+
+    .form-select:focus,
+    .form-control:focus {
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+
+    @media (max-width: 768px) {
         .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
-
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
-
-        .card:hover {
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        }
-
-        .btn-primary {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            padding: 0.625rem 1.25rem;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-primary:hover {
-            background-color: var(--primary-hover);
-            border-color: var(--primary-hover);
-            transform: translateY(-1px);
-        }
-
-        .btn-outline-primary {
-            color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
-
-        .btn-outline-primary:hover {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-        }
-
-        .table-container {
-            background: var(--card-background);
-            border-radius: 0.75rem;
-            overflow: hidden;
-            border: 1px solid var(--border-color);
-        }
-
-        .table th {
-            background-color: #f8fafc;
-            border-bottom: 1px solid var(--border-color);
-            font-weight: 600;
-            color: var(--text-primary);
-            padding: 1rem;
-            font-size: 0.875rem;
-        }
-
-        .table td {
-            padding: 1rem;
-            border-bottom: 1px solid #f1f5f9;
-            vertical-align: middle;
-        }
-
-        .badge {
-            font-weight: 500;
-            padding: 0.375rem 0.75rem;
-            border-radius: 0.375rem;
-            font-size: 0.75rem;
-        }
-
-        .badge.bg-success {
-            background-color: var(--success-color) !important;
-        }
-
-        .badge.bg-warning {
-            background-color: var(--warning-color) !important;
-        }
-
-        .badge.bg-danger {
-            background-color: var(--danger-color) !important;
-        }
-
-        .badge.bg-secondary {
-            background-color: var(--secondary-color) !important;
-        }
-
-        .empty-state {
-            text-align: center;
-            padding: 4rem 2rem;
-            color: var(--text-secondary);
-        }
-
-        .empty-state .empty-icon {
-            width: 4rem;
-            height: 4rem;
-            background-color: #f1f5f9;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 0 auto 1.5rem;
-        }
-
-        .empty-state .empty-icon i {
             font-size: 1.5rem;
-            color: var(--text-muted);
         }
 
-        .empty-state h3 {
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
+        .card-body {
+            padding: 1rem;
         }
+    }
+</style>
+{% endblock %}
 
-        .empty-state p {
-            color: var(--text-secondary);
-            margin-bottom: 1.5rem;
-        }
-
-        .loading-state {
-            text-align: center;
-            padding: 3rem 2rem;
-        }
-
-        .loading-spinner {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            color: var(--primary-color);
-        }
-
-        .loading-spinner .spinner-border {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        .form-select,
-        .form-control {
-            border-radius: 0.5rem;
-            border: 1px solid var(--border-color);
-            padding: 0.625rem 0.75rem;
-            transition: all 0.2s ease;
-            background-color: var(--card-background);
-        }
-
-        .form-select:focus,
-        .form-control:focus {
-            border-color: var(--primary-color);
-            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-        }
-
-        @media (max-width: 768px) {
-            .page-title {
-                font-size: 1.5rem;
-            }
-
-            .card-body {
-                padding: 1rem;
-            }
-        }
-    </style>
-</head>
-
-<body>
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/agents">Agents</a>
-                <a class="nav-link" href="/test-cases">Test Cases</a>
-                <a class="nav-link active" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
             <div class="mb-3 mb-lg-0">
@@ -409,9 +308,8 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script src="/static/js/regression-tests.js?v={{ static_asset_version }}"></script>
-</body>
-
-</html>
+{% endblock %}

--- a/templates/regression_tests.html
+++ b/templates/regression_tests.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Regression Tests - LLM Replay System</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --primary-color: #2563eb;
+            --primary-hover: #1d4ed8;
+            --secondary-color: #64748b;
+            --success-color: #059669;
+            --warning-color: #d97706;
+            --danger-color: #dc2626;
+            --background-color: #f8fafc;
+            --card-background: #ffffff;
+            --border-color: #e2e8f0;
+            --text-primary: #1e293b;
+            --text-secondary: #64748b;
+            --text-muted: #94a3b8;
+        }
+
+        body {
+            background-color: var(--background-color);
+            color: var(--text-primary);
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+
+        .navbar {
+            background: var(--card-background) !important;
+            border-bottom: 1px solid var(--border-color);
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            padding: 1rem 0;
+        }
+
+        .navbar-brand {
+            font-weight: 700;
+            color: var(--text-primary) !important;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .navbar-brand i {
+            color: var(--primary-color);
+            font-size: 1.5rem;
+        }
+
+        .navbar-nav .nav-link {
+            font-weight: 500;
+            color: var(--text-secondary) !important;
+            padding: 0.5rem 1rem !important;
+            border-radius: 0.375rem;
+            transition: all 0.2s ease;
+        }
+
+        .navbar-nav .nav-link:hover {
+            color: var(--primary-color) !important;
+            background-color: rgba(37, 99, 235, 0.1);
+        }
+
+        .navbar-nav .nav-link.active {
+            color: var(--primary-color) !important;
+            background-color: rgba(37, 99, 235, 0.1);
+            font-weight: 600;
+        }
+
+        .page-title {
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .page-subtitle {
+            color: var(--text-secondary);
+            font-size: 1rem;
+        }
+
+        .card {
+            background: var(--card-background);
+            border: 1px solid var(--border-color);
+            border-radius: 0.75rem;
+            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            transition: all 0.2s ease;
+        }
+
+        .card:hover {
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        }
+
+        .btn-primary {
+            background-color: var(--primary-color);
+            border-color: var(--primary-color);
+            font-weight: 500;
+            padding: 0.625rem 1.25rem;
+            border-radius: 0.5rem;
+            transition: all 0.2s ease;
+        }
+
+        .btn-primary:hover {
+            background-color: var(--primary-hover);
+            border-color: var(--primary-hover);
+            transform: translateY(-1px);
+        }
+
+        .btn-outline-primary {
+            color: var(--primary-color);
+            border-color: var(--primary-color);
+            font-weight: 500;
+            border-radius: 0.5rem;
+        }
+
+        .btn-outline-primary:hover {
+            background-color: var(--primary-color);
+            border-color: var(--primary-color);
+        }
+
+        .table-container {
+            background: var(--card-background);
+            border-radius: 0.75rem;
+            overflow: hidden;
+            border: 1px solid var(--border-color);
+        }
+
+        .table th {
+            background-color: #f8fafc;
+            border-bottom: 1px solid var(--border-color);
+            font-weight: 600;
+            color: var(--text-primary);
+            padding: 1rem;
+            font-size: 0.875rem;
+        }
+
+        .table td {
+            padding: 1rem;
+            border-bottom: 1px solid #f1f5f9;
+            vertical-align: middle;
+        }
+
+        .badge {
+            font-weight: 500;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.75rem;
+        }
+
+        .badge.bg-success {
+            background-color: var(--success-color) !important;
+        }
+
+        .badge.bg-warning {
+            background-color: var(--warning-color) !important;
+        }
+
+        .badge.bg-danger {
+            background-color: var(--danger-color) !important;
+        }
+
+        .badge.bg-secondary {
+            background-color: var(--secondary-color) !important;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 4rem 2rem;
+            color: var(--text-secondary);
+        }
+
+        .empty-state .empty-icon {
+            width: 4rem;
+            height: 4rem;
+            background-color: #f1f5f9;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 1.5rem;
+        }
+
+        .empty-state .empty-icon i {
+            font-size: 1.5rem;
+            color: var(--text-muted);
+        }
+
+        .empty-state h3 {
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .empty-state p {
+            color: var(--text-secondary);
+            margin-bottom: 1.5rem;
+        }
+
+        .loading-state {
+            text-align: center;
+            padding: 3rem 2rem;
+        }
+
+        .loading-spinner {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+            color: var(--primary-color);
+        }
+
+        .loading-spinner .spinner-border {
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+
+        .form-select,
+        .form-control {
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+            padding: 0.625rem 0.75rem;
+            transition: all 0.2s ease;
+            background-color: var(--card-background);
+        }
+
+        .form-select:focus,
+        .form-control:focus {
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+        }
+
+        @media (max-width: 768px) {
+            .page-title {
+                font-size: 1.5rem;
+            }
+
+            .card-body {
+                padding: 1rem;
+            }
+
+            .filter-group {
+                flex-direction: column;
+                align-items: stretch !important;
+            }
+
+            .filter-group > * {
+                width: 100% !important;
+                margin-bottom: 0.75rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <i class="fas fa-robot"></i>
+                <span>LLM Replay System</span>
+            </a>
+            <div class="navbar-nav ms-auto">
+                <a class="nav-link" href="/agents">Agents</a>
+                <a class="nav-link" href="/test-cases">Test Cases</a>
+                <a class="nav-link active" href="/regression-tests">Regression Tests</a>
+                <a class="nav-link" href="/test-execution">Execute Tests</a>
+                <a class="nav-link" href="/test-logs">Test Logs</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container py-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
+            <div class="mb-3 mb-lg-0">
+                <h1 class="page-title">
+                    <i class="fas fa-repeat me-3"></i>Regression Tests
+                </h1>
+                <p class="page-subtitle mb-0">Run every test case for an agent with consistent overrides</p>
+            </div>
+            <div class="d-flex align-items-center gap-3">
+                <button class="btn btn-outline-primary" id="refreshRegressionsBtn">
+                    <i class="fas fa-rotate me-2"></i>Refresh
+                </button>
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#startRegressionModal" id="startRegressionBtn">
+                    <i class="fas fa-rocket me-2"></i>Start Regression
+                </button>
+            </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-body py-3">
+                <div class="d-flex flex-wrap filter-group align-items-center gap-3">
+                    <div class="d-flex flex-column">
+                        <label class="text-muted fw-medium mb-1" for="agentFilter">Agent</label>
+                        <select class="form-select form-select-sm" id="agentFilter" style="min-width: 220px;">
+                            <option value="">All agents</option>
+                        </select>
+                    </div>
+                    <div class="d-flex flex-column">
+                        <label class="text-muted fw-medium mb-1" for="statusFilter">Status</label>
+                        <select class="form-select form-select-sm" id="statusFilter" style="min-width: 180px;">
+                            <option value="">All statuses</option>
+                            <option value="pending">Pending</option>
+                            <option value="running">Running</option>
+                            <option value="completed">Completed</option>
+                            <option value="failed">Failed</option>
+                        </select>
+                    </div>
+                    <div class="d-flex flex-column ms-auto">
+                        <label class="text-muted fw-medium mb-1">Actions</label>
+                        <div class="d-flex gap-2">
+                            <button class="btn btn-outline-secondary btn-sm" id="clearFiltersBtn">
+                                <i class="fas fa-eraser me-1"></i>Clear
+                            </button>
+                            <button class="btn btn-primary btn-sm" id="applyFiltersBtn">
+                                <i class="fas fa-filter me-1"></i>Apply
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="regressionNotice" class="alert alert-info d-none" role="alert">
+            <i class="fas fa-circle-info me-2"></i>
+            <span>Running regressions apply the agent's defaults to every case. Override values below if you need a custom run.</span>
+        </div>
+
+        <div class="table-container">
+            <table class="table table-hover mb-0" id="regressionTestsTable">
+                <thead>
+                    <tr>
+                        <th style="width: 20%">Agent</th>
+                        <th style="width: 14%">Status</th>
+                        <th style="width: 22%">Overrides</th>
+                        <th style="width: 16%">Results</th>
+                        <th style="width: 16%">Timing</th>
+                        <th style="width: 12%" class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="regressionTestsList">
+                    <!-- Regression tests will be injected here -->
+                </tbody>
+            </table>
+        </div>
+
+        <div id="loadingSpinner" class="loading-state d-none">
+            <div class="loading-spinner">
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                <span>Loading regression history...</span>
+            </div>
+        </div>
+
+        <div id="emptyState" class="empty-state d-none">
+            <div class="empty-icon">
+                <i class="fas fa-vial-circle-check"></i>
+            </div>
+            <h3>No regression runs yet</h3>
+            <p>Select an agent and launch your first regression to validate all of its test cases together.</p>
+            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#startRegressionModal">
+                <i class="fas fa-rocket me-2"></i>Start Regression
+            </button>
+        </div>
+    </div>
+
+    <!-- Start Regression Modal -->
+    <div class="modal fade" id="startRegressionModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Start Regression Run</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="startRegressionAlert"></div>
+                    <form id="startRegressionForm">
+                        <div class="mb-3">
+                            <label for="regressionAgentSelect" class="form-label">Agent *</label>
+                            <select class="form-select" id="regressionAgentSelect" required>
+                                <option value="">Select an agent...</option>
+                            </select>
+                            <div class="form-text">All active test cases belonging to this agent will run concurrently.</div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="regressionModelName" class="form-label">Model Name *</label>
+                                <input type="text" class="form-control" id="regressionModelName" required>
+                                <div class="form-text">Defaulted from the selected agent. Every execution will use this value.</div>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="regressionSystemPrompt" class="form-label">System Prompt *</label>
+                                <textarea class="form-control" id="regressionSystemPrompt" rows="4" required></textarea>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="regressionModelSettings" class="form-label">Model Settings (JSON) *</label>
+                            <textarea class="form-control" id="regressionModelSettings" rows="5" required></textarea>
+                            <div class="form-text">Provide the full settings payload used for every test case. Defaults to the agent's settings.</div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" id="confirmStartRegression">
+                        <i class="fas fa-rocket me-2"></i>Launch Regression
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/js/regression-tests.js?v={{ static_asset_version }}"></script>
+</body>
+
+</html>

--- a/templates/regression_tests.html
+++ b/templates/regression_tests.html
@@ -223,11 +223,11 @@
             <table class="table table-hover mb-0" id="regressionTestsTable">
                 <thead>
                     <tr>
-                        <th style="width: 20%">Agent</th>
+                        <th style="width: 22%">Agent</th>
                         <th style="width: 14%">Status</th>
-                        <th style="width: 22%">Overrides</th>
-                        <th style="width: 16%">Results</th>
-                        <th style="width: 16%">Timing</th>
+                        <th style="width: 18%">Model</th>
+                        <th style="width: 22%">Results</th>
+                        <th style="width: 16%">Created</th>
                         <th style="width: 12%" class="text-end">Actions</th>
                     </tr>
                 </thead>

--- a/templates/test_case_detail.html
+++ b/templates/test_case_detail.html
@@ -1,294 +1,191 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Test Case Details - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
-        }
+{% block page_title %}Test Case Details - LLM Replay System{% endblock %}
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
+{% block extra_css %}
+<style>
+    /* Page Header */
+    .page-header {
+        margin-bottom: 2rem;
+    }
 
-        /* Navigation Styles */
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
 
-        .navbar-brand i {
-            color: var(--primary-color);
+    /* Action buttons in header */
+    .page-header #actionButtons {
+        margin-top: 0.5rem;
+    }
+
+    /* Card Styles */
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
+
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    .card-header {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 1rem 1.5rem;
+        border-radius: 0.75rem 0.75rem 0 0 !important;
+    }
+
+    .card-body {
+        padding: 1.5rem;
+    }
+
+    /* Button Styles */
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
+
+    .btn-outline-secondary {
+        color: var(--text-secondary);
+        border-color: var(--border-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-outline-secondary:hover {
+        background-color: var(--text-secondary);
+        border-color: var(--text-secondary);
+        transform: translateY(-1px);
+    }
+
+    .btn-success {
+        background-color: var(--success-color);
+        border-color: var(--success-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    .btn-outline-danger {
+        color: var(--danger-color);
+        border-color: var(--danger-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    /* Table Styles */
+    .info-table {
+        margin-bottom: 0;
+    }
+
+    .info-table td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+
+    .info-table td:first-child {
+        font-weight: 600;
+        color: var(--text-secondary);
+        width: 150px;
+        background-color: #f8fafc;
+    }
+
+    .info-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    /* Code Block Styles */
+    .code-block {
+        background-color: #f1f5f9;
+        border: 1px solid var(--border-color);
+        border-radius: 0.5rem;
+        padding: 1rem;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        max-height: 400px;
+        overflow-y: auto;
+        color: var(--text-primary);
+        white-space: pre-wrap;
+        word-wrap: break-word;
+    }
+
+    /* Loading State */
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
+
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
+
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    /* Error Message */
+    .error-message {
+        background-color: #fef2f2;
+        border: 1px solid #fecaca;
+        color: var(--danger-color);
+        padding: 1rem;
+        border-radius: 0.5rem;
+        margin: 1rem 0;
+    }
+
+    /* Responsive Improvements */
+    @media (max-width: 768px) {
+        .page-title {
             font-size: 1.5rem;
         }
 
-        .brand-text {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
-
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
-
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
-
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
-
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
-
-        /* Page Header */
-        .page-header {
-            margin-bottom: 2rem;
-        }
-
-        .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
-
-        /* Action buttons in header */
-        .page-header #actionButtons {
-            margin-top: 0.5rem;
-        }
-
-        /* Card Styles */
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
-
-        .card:hover {
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        }
-
-        .card-header {
-            background-color: #f8fafc;
-            border-bottom: 1px solid var(--border-color);
-            font-weight: 600;
-            color: var(--text-primary);
-            padding: 1rem 1.5rem;
-            border-radius: 0.75rem 0.75rem 0 0 !important;
-        }
-
         .card-body {
-            padding: 1.5rem;
-        }
-
-        /* Button Styles */
-        .btn-primary {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            padding: 0.625rem 1.25rem;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-primary:hover {
-            background-color: var(--primary-hover);
-            border-color: var(--primary-hover);
-            transform: translateY(-1px);
-        }
-
-        .btn-outline-secondary {
-            color: var(--text-secondary);
-            border-color: var(--border-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-outline-secondary:hover {
-            background-color: var(--text-secondary);
-            border-color: var(--text-secondary);
-            transform: translateY(-1px);
-        }
-
-        .btn-success {
-            background-color: var(--success-color);
-            border-color: var(--success-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
-
-        .btn-outline-danger {
-            color: var(--danger-color);
-            border-color: var(--danger-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
-
-        /* Table Styles */
-        .info-table {
-            margin-bottom: 0;
-        }
-
-        .info-table td {
-            padding: 0.75rem 1rem;
-            border-bottom: 1px solid #f1f5f9;
-            vertical-align: middle;
+            padding: 1rem;
         }
 
         .info-table td:first-child {
-            font-weight: 600;
-            color: var(--text-secondary);
-            width: 150px;
-            background-color: #f8fafc;
-        }
-
-        .info-table tr:last-child td {
-            border-bottom: none;
-        }
-
-        /* Code Block Styles */
-        .code-block {
-            background-color: #f1f5f9;
-            border: 1px solid var(--border-color);
-            border-radius: 0.5rem;
-            padding: 1rem;
-            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+            width: 120px;
             font-size: 0.875rem;
-            line-height: 1.5;
-            max-height: 400px;
-            overflow-y: auto;
-            color: var(--text-primary);
-            white-space: pre-wrap;
-            word-wrap: break-word;
         }
 
-        /* Loading State */
-        .loading-state {
-            text-align: center;
-            padding: 3rem 2rem;
+        .btn-group {
+            flex-direction: column;
+            gap: 0.5rem;
         }
+    }
+</style>
+{% endblock %}
 
-        .loading-spinner {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            color: var(--primary-color);
-        }
-
-        .loading-spinner .spinner-border {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        /* Error Message */
-        .error-message {
-            background-color: #fef2f2;
-            border: 1px solid #fecaca;
-            color: var(--danger-color);
-            padding: 1rem;
-            border-radius: 0.5rem;
-            margin: 1rem 0;
-        }
-
-        /* Responsive Improvements */
-        @media (max-width: 768px) {
-            .page-title {
-                font-size: 1.5rem;
-            }
-
-            .card-body {
-                padding: 1rem;
-            }
-
-            .info-table td:first-child {
-                width: 120px;
-                font-size: 0.875rem;
-            }
-
-            .btn-group {
-                flex-direction: column;
-                gap: 0.5rem;
-            }
-        }
-    </style>
-</head>
-
-<body>
-    <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/agents">Agents</a>
-                <a class="nav-link active" href="/test-cases">Test Cases</a>
-                <a class="nav-link" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <!-- Header with Action Buttons -->
         <div class="page-header d-flex justify-content-between align-items-start">
@@ -334,340 +231,339 @@
             <!-- Content will be loaded here -->
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script>
-        const caseId = '{{ case_id }}';
-        let currentTestCase = null;
+            const caseId = '{{ case_id }}';
+            let currentTestCase = null;
 
-        document.addEventListener('DOMContentLoaded', function () {
-            loadTestCaseDetails();
-        });
+            document.addEventListener('DOMContentLoaded', function () {
+                loadTestCaseDetails();
+            });
 
-        async function loadTestCaseDetails() {
-            try {
-                const response = await fetch(`/v1/api/test-cases/${caseId}`);
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
+            async function loadTestCaseDetails() {
+                try {
+                    const response = await fetch(`/v1/api/test-cases/${caseId}`);
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+
+                    currentTestCase = await response.json();
+                    displayTestCaseDetails(currentTestCase);
+
+                    // Show action buttons and hide loading
+                    document.getElementById('actionButtons').classList.remove('d-none');
+                    document.getElementById('loadingSpinner').classList.add('d-none');
+                    document.getElementById('testCaseDetailsContent').classList.remove('d-none');
+
+                } catch (error) {
+                    console.error('Error loading test case details:', error);
+                    document.getElementById('errorText').textContent = 'Failed to load test case details: ' + error.message;
+                    document.getElementById('errorMessage').classList.remove('d-none');
+                    document.getElementById('loadingSpinner').classList.add('d-none');
+                }
+            }
+
+            // Helper function to format middle messages
+            function formatMiddleMessages(messages) {
+                if (!messages || messages.length === 0) {
+                    return '<div class="text-muted">No middle messages</div>';
                 }
 
-                currentTestCase = await response.json();
-                displayTestCaseDetails(currentTestCase);
+                return messages.map((message, index) => {
+                    const role = message.role || 'unknown';
+                    const content = message.content || '';
+                    const toolCalls = message.tool_calls || [];
+                    const roleColor = {
+                        'user': 'text-primary',
+                        'assistant': 'text-success',
+                        'tool': 'text-warning',
+                        'system': 'text-info'
+                    }[role] || 'text-secondary';
 
-                // Show action buttons and hide loading
-                document.getElementById('actionButtons').classList.remove('d-none');
-                document.getElementById('loadingSpinner').classList.add('d-none');
-                document.getElementById('testCaseDetailsContent').classList.remove('d-none');
+                    // Format tool calls if present
+                    const formatToolCalls = (calls) => {
+                        if (!calls || calls.length === 0) return '';
 
-            } catch (error) {
-                console.error('Error loading test case details:', error);
-                document.getElementById('errorText').textContent = 'Failed to load test case details: ' + error.message;
-                document.getElementById('errorMessage').classList.remove('d-none');
-                document.getElementById('loadingSpinner').classList.add('d-none');
-            }
-        }
+                        return calls.map((call, callIndex) => {
+                            const toolId = call.id || 'unknown';
+                            const toolName = call.function?.name || 'unknown';
+                            const toolArgs = call.function?.arguments || '';
 
-        // Helper function to format middle messages
-        function formatMiddleMessages(messages) {
-            if (!messages || messages.length === 0) {
-                return '<div class="text-muted">No middle messages</div>';
-            }
-
-            return messages.map((message, index) => {
-                const role = message.role || 'unknown';
-                const content = message.content || '';
-                const toolCalls = message.tool_calls || [];
-                const roleColor = {
-                    'user': 'text-primary',
-                    'assistant': 'text-success',
-                    'tool': 'text-warning',
-                    'system': 'text-info'
-                }[role] || 'text-secondary';
-
-                // Format tool calls if present
-                const formatToolCalls = (calls) => {
-                    if (!calls || calls.length === 0) return '';
-
-                    return calls.map((call, callIndex) => {
-                        const toolId = call.id || 'unknown';
-                        const toolName = call.function?.name || 'unknown';
-                        const toolArgs = call.function?.arguments || '';
-
-                        // Try to format arguments as JSON for better readability
-                        let formattedArgs = toolArgs;
-                        try {
-                            if (typeof toolArgs === 'string') {
-                                const parsed = JSON.parse(toolArgs);
-                                formattedArgs = JSON.stringify(parsed, null, 2);
-                            } else if (typeof toolArgs === 'object') {
-                                formattedArgs = JSON.stringify(toolArgs, null, 2);
+                            // Try to format arguments as JSON for better readability
+                            let formattedArgs = toolArgs;
+                            try {
+                                if (typeof toolArgs === 'string') {
+                                    const parsed = JSON.parse(toolArgs);
+                                    formattedArgs = JSON.stringify(parsed, null, 2);
+                                } else if (typeof toolArgs === 'object') {
+                                    formattedArgs = JSON.stringify(toolArgs, null, 2);
+                                }
+                            } catch (e) {
+                                // Keep original format if JSON parsing fails
+                                formattedArgs = String(toolArgs);
                             }
-                        } catch (e) {
-                            // Keep original format if JSON parsing fails
-                            formattedArgs = String(toolArgs);
-                        }
 
-                        return `
-                            <div class="mt-2 p-2 bg-warning bg-opacity-10 border border-warning border-opacity-25 rounded">
-                                <div class="d-flex align-items-center mb-1">
-                                    <i class="fas fa-tools text-warning me-2"></i>
-                                    <strong class="text-warning">Tool Call #${callIndex + 1}</strong>
+                            return `
+                                <div class="mt-2 p-2 bg-warning bg-opacity-10 border border-warning border-opacity-25 rounded">
+                                    <div class="d-flex align-items-center mb-1">
+                                        <i class="fas fa-tools text-warning me-2"></i>
+                                        <strong class="text-warning">Tool Call #${callIndex + 1}</strong>
+                                    </div>
+                                    <div class="small">
+                                        <div><strong>Name:</strong> <code>${escapeHtml(toolName)}</code></div>
+                                        <div><strong>ID:</strong> <code>${escapeHtml(toolId)}</code></div>
+                                        <div><strong>Arguments:</strong></div>
+                                        <pre class="bg-light p-2 rounded mt-1 mb-0" style="font-size: 0.8em; max-height: 100px; overflow-y: auto;">${escapeHtml(formattedArgs)}</pre>
+                                    </div>
                                 </div>
-                                <div class="small">
-                                    <div><strong>Name:</strong> <code>${escapeHtml(toolName)}</code></div>
-                                    <div><strong>ID:</strong> <code>${escapeHtml(toolId)}</code></div>
-                                    <div><strong>Arguments:</strong></div>
-                                    <pre class="bg-light p-2 rounded mt-1 mb-0" style="font-size: 0.8em; max-height: 100px; overflow-y: auto;">${escapeHtml(formattedArgs)}</pre>
-                                </div>
-                            </div>
-                        `;
-                    }).join('');
-                };
+                            `;
+                        }).join('');
+                    };
 
-                return `
-                    <div class="mb-2 border-start border-3 ps-2" style="border-color: var(--bs-${role === 'user' ? 'primary' : role === 'assistant' ? 'success' : role === 'tool' ? 'warning' : 'secondary'}) !important;">
-                        <div class="d-flex align-items-center mb-1">
-                            <span class="badge bg-secondary me-2">#${index + 1}</span>
-                            <strong class="${roleColor}">${escapeHtml(role.toUpperCase())}</strong>
-                            ${toolCalls.length > 0 ? `<span class="badge bg-warning ms-2">${toolCalls.length} tool call${toolCalls.length > 1 ? 's' : ''}</span>` : ''}
+                    return `
+                        <div class="mb-2 border-start border-3 ps-2" style="border-color: var(--bs-${role === 'user' ? 'primary' : role === 'assistant' ? 'success' : role === 'tool' ? 'warning' : 'secondary'}) !important;">
+                            <div class="d-flex align-items-center mb-1">
+                                <span class="badge bg-secondary me-2">#${index + 1}</span>
+                                <strong class="${roleColor}">${escapeHtml(role.toUpperCase())}</strong>
+                                ${toolCalls.length > 0 ? `<span class="badge bg-warning ms-2">${toolCalls.length} tool call${toolCalls.length > 1 ? 's' : ''}</span>` : ''}
+                            </div>
+                            ${content ? `<pre class="bg-light p-2 rounded mb-0" style="font-size: 0.85em; max-height: 150px; overflow-y: auto;">${escapeHtml(content)}</pre>` : ''}
+                            ${formatToolCalls(toolCalls)}
                         </div>
-                        ${content ? `<pre class="bg-light p-2 rounded mb-0" style="font-size: 0.85em; max-height: 150px; overflow-y: auto;">${escapeHtml(content)}</pre>` : ''}
-                        ${formatToolCalls(toolCalls)}
-                    </div>
-                `;
-            }).join('');
-        }
+                    `;
+                }).join('');
+            }
 
-        function displayTestCaseDetails(testCase) {
-            const agentName = testCase.agent ? testCase.agent.name : null;
-            const agentId = testCase.agent_id || '';
-            const agentBadge = agentName
-                ? `<span class="badge bg-primary">${escapeHtml(agentName)}</span>`
-                : '<span class="text-muted">Unknown agent</span>';
-            const agentIdHtml = agentId ? `<small class="text-muted ms-2">${escapeHtml(agentId)}</small>` : '';
-            const agentLinks = agentId
-                ? `
-                    <div class="mt-2 small">
-                        <a href="/test-cases?agentId=${encodeURIComponent(agentId)}" class="text-decoration-none" target="_blank">
-                            View test cases for this agent
-                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                        </a>
-                        <span class="text-muted mx-1">•</span>
-                        <a href="/agents" class="text-decoration-none" target="_blank">
-                            Manage agents
-                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                        </a>
-                    </div>
-                `
-                : '';
-
-            const detailsHtml = `
-                <div class="row">
-                    <!-- Left Column -->
-                    <div class="col-md-6">
-                        <!-- Basic Information -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <i class="fas fa-info-circle me-2"></i>Basic Information
-                            </div>
-                            <div class="card-body p-0">
-                                <table class="table info-table mb-0">
-                                    <tr>
-                                        <td>Test Case ID:</td>
-                                        <td><code>${escapeHtml(testCase.id)}</code></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Name:</td>
-                                        <td><strong>${escapeHtml(testCase.name)}</strong></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Description:</td>
-                                        <td>${escapeHtml(testCase.description || 'No description provided')}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Agent:</td>
-                                        <td>
-                                            <div class="d-flex flex-column">
-                                                <div>
-                                                    ${agentBadge}
-                                                    ${agentIdHtml}
-                                                </div>
-                                                ${agentLinks}
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Created At:</td>
-                                        <td>${formatDate(testCase.created_at)}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Updated At:</td>
-                                        <td>${formatDate(testCase.updated_at)}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Model Name:</td>
-                                        <td><code>${escapeHtml(testCase.model_name)}</code></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Model Settings:</td>
-                                        <td>${testCase.model_settings !== null && testCase.model_settings !== undefined ? `<pre class="bg-light p-2 rounded"><code>${escapeHtml(JSON.stringify(testCase.model_settings, null, 2))}</code></pre>` : '<span class="text-muted">Not specified</span>'}</td>
-                                    </tr>
-                                </table>
-                            </div>
+            function displayTestCaseDetails(testCase) {
+                const agentName = testCase.agent ? testCase.agent.name : null;
+                const agentId = testCase.agent_id || '';
+                const agentBadge = agentName
+                    ? `<span class="badge bg-primary">${escapeHtml(agentName)}</span>`
+                    : '<span class="text-muted">Unknown agent</span>';
+                const agentIdHtml = agentId ? `<small class="text-muted ms-2">${escapeHtml(agentId)}</small>` : '';
+                const agentLinks = agentId
+                    ? `
+                        <div class="mt-2 small">
+                            <a href="/test-cases?agentId=${encodeURIComponent(agentId)}" class="text-decoration-none" target="_blank">
+                                View test cases for this agent
+                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                            </a>
+                            <span class="text-muted mx-1">•</span>
+                            <a href="/agents" class="text-decoration-none" target="_blank">
+                                Manage agents
+                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                            </a>
                         </div>
+                    `
+                    : '';
 
-                        <!-- Middle Messages -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <i class="fas fa-comments me-2"></i>Middle Messages
-                            </div>
-                            <div class="card-body">
-                                <div style="max-height: 400px; overflow-y: auto;">
-                                    ${formatMiddleMessages(testCase.middle_messages)}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Right Column -->
-                    <div class="col-md-6">
-                        <!-- System Prompt -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <i class="fas fa-terminal me-2"></i>System Prompt
-                            </div>
-                            <div class="card-body">
-                                <div class="code-block">${escapeHtml(testCase.system_prompt || 'No system prompt provided')}</div>
-                            </div>
-                        </div>
-
-                        <!-- User Message -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <i class="fas fa-comment me-2"></i>User Message
-                            </div>
-                            <div class="card-body">
-                                <div class="code-block">${escapeHtml(testCase.last_user_message || 'No user message provided')}</div>
-                            </div>
-                        </div>
-
-                        <!-- Tools Configuration -->
-                        ${testCase.tools && testCase.tools.length > 0 ? `
+                const detailsHtml = `
+                    <div class="row">
+                        <!-- Left Column -->
+                        <div class="col-md-6">
+                            <!-- Basic Information -->
                             <div class="card mb-4">
                                 <div class="card-header">
-                                    <i class="fas fa-wrench me-2"></i>Tools Configuration
+                                    <i class="fas fa-info-circle me-2"></i>Basic Information
+                                </div>
+                                <div class="card-body p-0">
+                                    <table class="table info-table mb-0">
+                                        <tr>
+                                            <td>Test Case ID:</td>
+                                            <td><code>${escapeHtml(testCase.id)}</code></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Name:</td>
+                                            <td><strong>${escapeHtml(testCase.name)}</strong></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Description:</td>
+                                            <td>${escapeHtml(testCase.description || 'No description provided')}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Agent:</td>
+                                            <td>
+                                                <div class="d-flex flex-column">
+                                                    <div>
+                                                        ${agentBadge}
+                                                        ${agentIdHtml}
+                                                    </div>
+                                                    ${agentLinks}
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Created At:</td>
+                                            <td>${formatDate(testCase.created_at)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Updated At:</td>
+                                            <td>${formatDate(testCase.updated_at)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Model Name:</td>
+                                            <td><code>${escapeHtml(testCase.model_name)}</code></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Model Settings:</td>
+                                            <td>${testCase.model_settings !== null && testCase.model_settings !== undefined ? `<pre class="bg-light p-2 rounded"><code>${escapeHtml(JSON.stringify(testCase.model_settings, null, 2))}</code></pre>` : '<span class="text-muted">Not specified</span>'}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+
+                            <!-- Middle Messages -->
+                            <div class="card mb-4">
+                                <div class="card-header">
+                                    <i class="fas fa-comments me-2"></i>Middle Messages
                                 </div>
                                 <div class="card-body">
-                                    <div class="accordion" id="testCaseToolsAccordion">
-                                        ${testCase.tools.map((tool, index) => `
-                                            <div class="accordion-item">
-                                                <h2 class="accordion-header" id="testCaseHeading${index}">
-                                                    <button class="accordion-button collapsed" type="button"
-                                                            data-bs-toggle="collapse" data-bs-target="#testCaseCollapse${index}"
-                                                            aria-expanded="false" aria-controls="testCaseCollapse${index}">
-                                                        <i class="fas fa-wrench me-2"></i>
-                                                        <strong>${escapeHtml(tool.function?.name || 'Unknown Tool')}</strong>
-                                                    </button>
-                                                </h2>
-                                                <div id="testCaseCollapse${index}" class="accordion-collapse collapse"
-                                                     aria-labelledby="testCaseHeading${index}" data-bs-parent="#testCaseToolsAccordion">
-                                                    <div class="accordion-body">
-                                                        <div class="code-block" style="font-size: 0.85em;">${escapeHtml(JSON.stringify(tool, null, 2))}</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        `).join('')}
+                                    <div style="max-height: 400px; overflow-y: auto;">
+                                        ${formatMiddleMessages(testCase.middle_messages)}
                                     </div>
                                 </div>
                             </div>
-                        ` : `
+                        </div>
+
+                        <!-- Right Column -->
+                        <div class="col-md-6">
+                            <!-- System Prompt -->
                             <div class="card mb-4">
                                 <div class="card-header">
-                                    <i class="fas fa-wrench me-2"></i>Tools
+                                    <i class="fas fa-terminal me-2"></i>System Prompt
                                 </div>
                                 <div class="card-body">
-                                    <p class="text-muted mb-0">No tools configured</p>
+                                    <div class="code-block">${escapeHtml(testCase.system_prompt || 'No system prompt provided')}</div>
                                 </div>
                             </div>
-                        `}
+
+                            <!-- User Message -->
+                            <div class="card mb-4">
+                                <div class="card-header">
+                                    <i class="fas fa-comment me-2"></i>User Message
+                                </div>
+                                <div class="card-body">
+                                    <div class="code-block">${escapeHtml(testCase.last_user_message || 'No user message provided')}</div>
+                                </div>
+                            </div>
+
+                            <!-- Tools Configuration -->
+                            ${testCase.tools && testCase.tools.length > 0 ? `
+                                <div class="card mb-4">
+                                    <div class="card-header">
+                                        <i class="fas fa-wrench me-2"></i>Tools Configuration
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="accordion" id="testCaseToolsAccordion">
+                                            ${testCase.tools.map((tool, index) => `
+                                                <div class="accordion-item">
+                                                    <h2 class="accordion-header" id="testCaseHeading${index}">
+                                                        <button class="accordion-button collapsed" type="button"
+                                                                data-bs-toggle="collapse" data-bs-target="#testCaseCollapse${index}"
+                                                                aria-expanded="false" aria-controls="testCaseCollapse${index}">
+                                                            <i class="fas fa-wrench me-2"></i>
+                                                            <strong>${escapeHtml(tool.function?.name || 'Unknown Tool')}</strong>
+                                                        </button>
+                                                    </h2>
+                                                    <div id="testCaseCollapse${index}" class="accordion-collapse collapse"
+                                                         aria-labelledby="testCaseHeading${index}" data-bs-parent="#testCaseToolsAccordion">
+                                                        <div class="accordion-body">
+                                                            <div class="code-block" style="font-size: 0.85em;">${escapeHtml(JSON.stringify(tool, null, 2))}</div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            `).join('')}
+                                        </div>
+                                    </div>
+                                </div>
+                            ` : `
+                                <div class="card mb-4">
+                                    <div class="card-header">
+                                        <i class="fas fa-wrench me-2"></i>Tools
+                                    </div>
+                                    <div class="card-body">
+                                        <p class="text-muted mb-0">No tools configured</p>
+                                    </div>
+                                </div>
+                            `}
+                        </div>
                     </div>
-                </div>
-            `;
+                `;
 
-            document.getElementById('testCaseDetailsContent').innerHTML = detailsHtml;
-        }
-
-        function escapeHtml(text) {
-            if (text === null || text === undefined) return '';
-            const map = {
-                '&': '&amp;',
-                '<': '&lt;',
-                '>': '&gt;',
-                '"': '&quot;',
-                "'": '&#039;'
-            };
-            return text.toString().replace(/[&<>"']/g, function (m) { return map[m]; });
-        }
-
-        function formatDate(dateString) {
-            if (!dateString) return 'N/A';
-            const date = new Date(dateString);
-            return date.toLocaleString('en-US', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-                hour: '2-digit',
-                minute: '2-digit',
-                second: '2-digit'
-            });
-        }
-
-        async function executeTest() {
-            if (!currentTestCase) return;
-
-            try {
-                // Redirect to test execution page with this test case
-                window.open(`/test-execution?testCaseId=${currentTestCase.id}`, '_blank');
-            } catch (error) {
-                console.error('Error executing test:', error);
-                alert('Error executing test: ' + error.message);
-            }
-        }
-
-        function viewTestLogs() {
-            if (currentTestCase) {
-                window.open(`/test-logs?testCaseId=${currentTestCase.id}`, '_blank');
-            } else {
-                window.open('/test-logs', '_blank');
-            }
-        }
-
-        async function deleteTestCase() {
-            if (!currentTestCase) return;
-
-            if (!confirm(`Are you sure you want to delete the test case "${currentTestCase.name}"? This action cannot be undone.`)) {
-                return;
+                document.getElementById('testCaseDetailsContent').innerHTML = detailsHtml;
             }
 
-            try {
-                const response = await fetch(`/v1/api/test-cases/${currentTestCase.id}`, {
-                    method: 'DELETE'
+            function escapeHtml(text) {
+                if (text === null || text === undefined) return '';
+                const map = {
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#039;'
+                };
+                return text.toString().replace(/[&<>"']/g, function (m) { return map[m]; });
+            }
+
+            function formatDate(dateString) {
+                if (!dateString) return 'N/A';
+                const date = new Date(dateString);
+                return date.toLocaleString('en-US', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit'
                 });
+            }
 
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
+            async function executeTest() {
+                if (!currentTestCase) return;
+
+                try {
+                    // Redirect to test execution page with this test case
+                    window.open(`/test-execution?testCaseId=${currentTestCase.id}`, '_blank');
+                } catch (error) {
+                    console.error('Error executing test:', error);
+                    alert('Error executing test: ' + error.message);
+                }
+            }
+
+            function viewTestLogs() {
+                if (currentTestCase) {
+                    window.open(`/test-logs?testCaseId=${currentTestCase.id}`, '_blank');
+                } else {
+                    window.open('/test-logs', '_blank');
+                }
+            }
+
+            async function deleteTestCase() {
+                if (!currentTestCase) return;
+
+                if (!confirm(`Are you sure you want to delete the test case "${currentTestCase.name}"? This action cannot be undone.`)) {
+                    return;
                 }
 
-                alert('Test case deleted successfully!');
-                // Redirect back to test cases page
-                window.location.href = '/test-cases';
+                try {
+                    const response = await fetch(`/v1/api/test-cases/${currentTestCase.id}`, {
+                        method: 'DELETE'
+                    });
 
-            } catch (error) {
-                console.error('Error deleting test case:', error);
-                alert('Error deleting test case: ' + error.message);
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+
+                    alert('Test case deleted successfully!');
+                    // Redirect back to test cases page
+                    window.location.href = '/test-cases';
+
+                } catch (error) {
+                    console.error('Error deleting test case:', error);
+                    alert('Error deleting test case: ' + error.message);
+                }
             }
-        }
-    </script>
-</body>
-
-</html>
+        </script>
+{% endblock %}

--- a/templates/test_case_detail.html
+++ b/templates/test_case_detail.html
@@ -506,6 +506,29 @@
                                 </div>
                             </div>
                         </div>
+                    </div>
+
+                    <!-- Right Column -->
+                    <div class="col-md-6">
+                        <!-- System Prompt -->
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <i class="fas fa-terminal me-2"></i>System Prompt
+                            </div>
+                            <div class="card-body">
+                                <div class="code-block">${escapeHtml(testCase.system_prompt || 'No system prompt provided')}</div>
+                            </div>
+                        </div>
+
+                        <!-- User Message -->
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <i class="fas fa-comment me-2"></i>User Message
+                            </div>
+                            <div class="card-body">
+                                <div class="code-block">${escapeHtml(testCase.last_user_message || 'No user message provided')}</div>
+                            </div>
+                        </div>
 
                         <!-- Tools Configuration -->
                         ${testCase.tools && testCase.tools.length > 0 ? `
@@ -546,29 +569,6 @@
                                 </div>
                             </div>
                         `}
-                    </div>
-
-                    <!-- Right Column -->
-                    <div class="col-md-6">
-                        <!-- System Prompt -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <i class="fas fa-terminal me-2"></i>System Prompt
-                            </div>
-                            <div class="card-body">
-                                <div class="code-block">${escapeHtml(testCase.system_prompt || 'No system prompt provided')}</div>
-                            </div>
-                        </div>
-
-                        <!-- User Message -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <i class="fas fa-comment me-2"></i>User Message
-                            </div>
-                            <div class="card-body">
-                                <div class="code-block">${escapeHtml(testCase.last_user_message || 'No user message provided')}</div>
-                            </div>
-                        </div>
                     </div>
                 </div>
             `;

--- a/templates/test_case_detail.html
+++ b/templates/test_case_detail.html
@@ -186,126 +186,126 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container py-4">
-        <!-- Header with Action Buttons -->
-        <div class="page-header d-flex justify-content-between align-items-start">
-            <div>
-                <h1 class="page-title">
-                    <i class="fas fa-file-code me-3"></i>Test Case Details
-                </h1>
-                <p class="page-subtitle">Detailed view of test case configuration</p>
-            </div>
-            <div id="actionButtons" class="d-none">
-                <div class="d-flex gap-2">
-                    <button type="button" class="btn btn-outline-secondary" onclick="viewTestLogs()">
-                        <i class="fas fa-history me-2"></i>View Test Logs
-                    </button>
-                    <button type="button" class="btn btn-success" onclick="executeTest()">
-                        <i class="fas fa-play me-2"></i>Execute Test
-                    </button>
-                    <button type="button" class="btn btn-outline-danger" onclick="deleteTestCase()">
-                        <i class="fas fa-trash me-2"></i>Delete Test Case
-                    </button>
-                </div>
-            </div>
+<div class="container py-4">
+    <!-- Header with Action Buttons -->
+    <div class="page-header d-flex justify-content-between align-items-start">
+        <div>
+            <h1 class="page-title">
+                <i class="fas fa-file-code me-3"></i>Test Case Details
+            </h1>
+            <p class="page-subtitle">Detailed view of test case configuration</p>
         </div>
-
-        <!-- Loading Spinner -->
-        <div id="loadingSpinner" class="loading-state">
-            <div class="loading-spinner">
-                <div class="spinner-border" role="status">
-                    <span class="visually-hidden">Loading...</span>
-                </div>
-                <span>Loading test case details...</span>
+        <div id="actionButtons" class="d-none">
+            <div class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-secondary" onclick="viewTestLogs()">
+                    <i class="fas fa-history me-2"></i>View Test Logs
+                </button>
+                <button type="button" class="btn btn-success" onclick="executeTest()">
+                    <i class="fas fa-play me-2"></i>Execute Test
+                </button>
+                <button type="button" class="btn btn-outline-danger" onclick="deleteTestCase()">
+                    <i class="fas fa-trash me-2"></i>Delete Test Case
+                </button>
             </div>
-        </div>
-
-        <!-- Error Message -->
-        <div id="errorMessage" class="error-message d-none">
-            <i class="fas fa-exclamation-triangle me-2"></i>
-            <span id="errorText"></span>
-        </div>
-
-        <!-- Test Case Details Content -->
-        <div id="testCaseDetailsContent" class="d-none">
-            <!-- Content will be loaded here -->
         </div>
     </div>
+
+    <!-- Loading Spinner -->
+    <div id="loadingSpinner" class="loading-state">
+        <div class="loading-spinner">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+            <span>Loading test case details...</span>
+        </div>
+    </div>
+
+    <!-- Error Message -->
+    <div id="errorMessage" class="error-message d-none">
+        <i class="fas fa-exclamation-triangle me-2"></i>
+        <span id="errorText"></span>
+    </div>
+
+    <!-- Test Case Details Content -->
+    <div id="testCaseDetailsContent" class="d-none">
+        <!-- Content will be loaded here -->
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}
-    <script>
-            const caseId = '{{ case_id }}';
-            let currentTestCase = null;
+<script>
+    const caseId = '{{ case_id }}';
+    let currentTestCase = null;
 
-            document.addEventListener('DOMContentLoaded', function () {
-                loadTestCaseDetails();
-            });
+    document.addEventListener('DOMContentLoaded', function () {
+        loadTestCaseDetails();
+    });
 
-            async function loadTestCaseDetails() {
-                try {
-                    const response = await fetch(`/v1/api/test-cases/${caseId}`);
-                    if (!response.ok) {
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
-
-                    currentTestCase = await response.json();
-                    displayTestCaseDetails(currentTestCase);
-
-                    // Show action buttons and hide loading
-                    document.getElementById('actionButtons').classList.remove('d-none');
-                    document.getElementById('loadingSpinner').classList.add('d-none');
-                    document.getElementById('testCaseDetailsContent').classList.remove('d-none');
-
-                } catch (error) {
-                    console.error('Error loading test case details:', error);
-                    document.getElementById('errorText').textContent = 'Failed to load test case details: ' + error.message;
-                    document.getElementById('errorMessage').classList.remove('d-none');
-                    document.getElementById('loadingSpinner').classList.add('d-none');
-                }
+    async function loadTestCaseDetails() {
+        try {
+            const response = await fetch(`/v1/api/test-cases/${caseId}`);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
             }
 
-            // Helper function to format middle messages
-            function formatMiddleMessages(messages) {
-                if (!messages || messages.length === 0) {
-                    return '<div class="text-muted">No middle messages</div>';
-                }
+            currentTestCase = await response.json();
+            displayTestCaseDetails(currentTestCase);
 
-                return messages.map((message, index) => {
-                    const role = message.role || 'unknown';
-                    const content = message.content || '';
-                    const toolCalls = message.tool_calls || [];
-                    const roleColor = {
-                        'user': 'text-primary',
-                        'assistant': 'text-success',
-                        'tool': 'text-warning',
-                        'system': 'text-info'
-                    }[role] || 'text-secondary';
+            // Show action buttons and hide loading
+            document.getElementById('actionButtons').classList.remove('d-none');
+            document.getElementById('loadingSpinner').classList.add('d-none');
+            document.getElementById('testCaseDetailsContent').classList.remove('d-none');
 
-                    // Format tool calls if present
-                    const formatToolCalls = (calls) => {
-                        if (!calls || calls.length === 0) return '';
+        } catch (error) {
+            console.error('Error loading test case details:', error);
+            document.getElementById('errorText').textContent = 'Failed to load test case details: ' + error.message;
+            document.getElementById('errorMessage').classList.remove('d-none');
+            document.getElementById('loadingSpinner').classList.add('d-none');
+        }
+    }
 
-                        return calls.map((call, callIndex) => {
-                            const toolId = call.id || 'unknown';
-                            const toolName = call.function?.name || 'unknown';
-                            const toolArgs = call.function?.arguments || '';
+    // Helper function to format middle messages
+    function formatMiddleMessages(messages) {
+        if (!messages || messages.length === 0) {
+            return '<div class="text-muted">No middle messages</div>';
+        }
 
-                            // Try to format arguments as JSON for better readability
-                            let formattedArgs = toolArgs;
-                            try {
-                                if (typeof toolArgs === 'string') {
-                                    const parsed = JSON.parse(toolArgs);
-                                    formattedArgs = JSON.stringify(parsed, null, 2);
-                                } else if (typeof toolArgs === 'object') {
-                                    formattedArgs = JSON.stringify(toolArgs, null, 2);
-                                }
-                            } catch (e) {
-                                // Keep original format if JSON parsing fails
-                                formattedArgs = String(toolArgs);
-                            }
+        return messages.map((message, index) => {
+            const role = message.role || 'unknown';
+            const content = message.content || '';
+            const toolCalls = message.tool_calls || [];
+            const roleColor = {
+                'user': 'text-primary',
+                'assistant': 'text-success',
+                'tool': 'text-warning',
+                'system': 'text-info'
+            }[role] || 'text-secondary';
 
-                            return `
+            // Format tool calls if present
+            const formatToolCalls = (calls) => {
+                if (!calls || calls.length === 0) return '';
+
+                return calls.map((call, callIndex) => {
+                    const toolId = call.id || 'unknown';
+                    const toolName = call.function?.name || 'unknown';
+                    const toolArgs = call.function?.arguments || '';
+
+                    // Try to format arguments as JSON for better readability
+                    let formattedArgs = toolArgs;
+                    try {
+                        if (typeof toolArgs === 'string') {
+                            const parsed = JSON.parse(toolArgs);
+                            formattedArgs = JSON.stringify(parsed, null, 2);
+                        } else if (typeof toolArgs === 'object') {
+                            formattedArgs = JSON.stringify(toolArgs, null, 2);
+                        }
+                    } catch (e) {
+                        // Keep original format if JSON parsing fails
+                        formattedArgs = String(toolArgs);
+                    }
+
+                    return `
                                 <div class="mt-2 p-2 bg-warning bg-opacity-10 border border-warning border-opacity-25 rounded">
                                     <div class="d-flex align-items-center mb-1">
                                         <i class="fas fa-tools text-warning me-2"></i>
@@ -319,10 +319,10 @@
                                     </div>
                                 </div>
                             `;
-                        }).join('');
-                    };
+                }).join('');
+            };
 
-                    return `
+            return `
                         <div class="mb-2 border-start border-3 ps-2" style="border-color: var(--bs-${role === 'user' ? 'primary' : role === 'assistant' ? 'success' : role === 'tool' ? 'warning' : 'secondary'}) !important;">
                             <div class="d-flex align-items-center mb-1">
                                 <span class="badge bg-secondary me-2">#${index + 1}</span>
@@ -333,33 +333,17 @@
                             ${formatToolCalls(toolCalls)}
                         </div>
                     `;
-                }).join('');
-            }
+        }).join('');
+    }
 
-            function displayTestCaseDetails(testCase) {
-                const agentName = testCase.agent ? testCase.agent.name : null;
-                const agentId = testCase.agent_id || '';
-                const agentBadge = agentName
-                    ? `<span class="badge bg-primary">${escapeHtml(agentName)}</span>`
-                    : '<span class="text-muted">Unknown agent</span>';
-                const agentIdHtml = agentId ? `<small class="text-muted ms-2">${escapeHtml(agentId)}</small>` : '';
-                const agentLinks = agentId
-                    ? `
-                        <div class="mt-2 small">
-                            <a href="/test-cases?agentId=${encodeURIComponent(agentId)}" class="text-decoration-none" target="_blank">
-                                View test cases for this agent
-                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                            </a>
-                            <span class="text-muted mx-1">•</span>
-                            <a href="/agents" class="text-decoration-none" target="_blank">
-                                Manage agents
-                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                            </a>
-                        </div>
-                    `
-                    : '';
+    function displayTestCaseDetails(testCase) {
+        const agentName = testCase.agent ? testCase.agent.name : null;
+        const agentId = testCase.agent_id || '';
+        const agentBadge = agentName && agentId
+            ? `<a href="/agents/${escapeHtml(agentId)}" class="badge bg-primary text-decoration-none" target="_blank">${escapeHtml(agentName)}</a>`
+            : '<span class="text-muted">Unknown agent</span>';
 
-                const detailsHtml = `
+        const detailsHtml = `
                     <div class="row">
                         <!-- Left Column -->
                         <div class="col-md-6">
@@ -384,15 +368,7 @@
                                         </tr>
                                         <tr>
                                             <td>Agent:</td>
-                                            <td>
-                                                <div class="d-flex flex-column">
-                                                    <div>
-                                                        ${agentBadge}
-                                                        ${agentIdHtml}
-                                                    </div>
-                                                    ${agentLinks}
-                                                </div>
-                                            </td>
+                                            <td>${agentBadge}</td>
                                         </tr>
                                         <tr>
                                             <td>Created At:</td>
@@ -492,78 +468,78 @@
                     </div>
                 `;
 
-                document.getElementById('testCaseDetailsContent').innerHTML = detailsHtml;
+        document.getElementById('testCaseDetailsContent').innerHTML = detailsHtml;
+    }
+
+    function escapeHtml(text) {
+        if (text === null || text === undefined) return '';
+        const map = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        };
+        return text.toString().replace(/[&<>"']/g, function (m) { return map[m]; });
+    }
+
+    function formatDate(dateString) {
+        if (!dateString) return 'N/A';
+        const date = new Date(dateString);
+        return date.toLocaleString('en-US', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit'
+        });
+    }
+
+    async function executeTest() {
+        if (!currentTestCase) return;
+
+        try {
+            // Redirect to test execution page with this test case
+            window.open(`/test-execution?testCaseId=${currentTestCase.id}`, '_blank');
+        } catch (error) {
+            console.error('Error executing test:', error);
+            alert('Error executing test: ' + error.message);
+        }
+    }
+
+    function viewTestLogs() {
+        if (currentTestCase) {
+            window.open(`/test-logs?testCaseId=${currentTestCase.id}`, '_blank');
+        } else {
+            window.open('/test-logs', '_blank');
+        }
+    }
+
+    async function deleteTestCase() {
+        if (!currentTestCase) return;
+
+        if (!confirm(`Are you sure you want to delete the test case "${currentTestCase.name}"? This action cannot be undone.`)) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`/v1/api/test-cases/${currentTestCase.id}`, {
+                method: 'DELETE'
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
             }
 
-            function escapeHtml(text) {
-                if (text === null || text === undefined) return '';
-                const map = {
-                    '&': '&amp;',
-                    '<': '&lt;',
-                    '>': '&gt;',
-                    '"': '&quot;',
-                    "'": '&#039;'
-                };
-                return text.toString().replace(/[&<>"']/g, function (m) { return map[m]; });
-            }
+            alert('Test case deleted successfully!');
+            // Redirect back to test cases page
+            window.location.href = '/test-cases';
 
-            function formatDate(dateString) {
-                if (!dateString) return 'N/A';
-                const date = new Date(dateString);
-                return date.toLocaleString('en-US', {
-                    year: 'numeric',
-                    month: '2-digit',
-                    day: '2-digit',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    second: '2-digit'
-                });
-            }
-
-            async function executeTest() {
-                if (!currentTestCase) return;
-
-                try {
-                    // Redirect to test execution page with this test case
-                    window.open(`/test-execution?testCaseId=${currentTestCase.id}`, '_blank');
-                } catch (error) {
-                    console.error('Error executing test:', error);
-                    alert('Error executing test: ' + error.message);
-                }
-            }
-
-            function viewTestLogs() {
-                if (currentTestCase) {
-                    window.open(`/test-logs?testCaseId=${currentTestCase.id}`, '_blank');
-                } else {
-                    window.open('/test-logs', '_blank');
-                }
-            }
-
-            async function deleteTestCase() {
-                if (!currentTestCase) return;
-
-                if (!confirm(`Are you sure you want to delete the test case "${currentTestCase.name}"? This action cannot be undone.`)) {
-                    return;
-                }
-
-                try {
-                    const response = await fetch(`/v1/api/test-cases/${currentTestCase.id}`, {
-                        method: 'DELETE'
-                    });
-
-                    if (!response.ok) {
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
-
-                    alert('Test case deleted successfully!');
-                    // Redirect back to test cases page
-                    window.location.href = '/test-cases';
-
-                } catch (error) {
-                    console.error('Error deleting test case:', error);
-                    alert('Error deleting test case: ' + error.message);
-                }
-            }
-        </script>
+        } catch (error) {
+            console.error('Error deleting test case:', error);
+            alert('Error deleting test case: ' + error.message);
+        }
+    }
+</script>
 {% endblock %}

--- a/templates/test_case_detail.html
+++ b/templates/test_case_detail.html
@@ -50,6 +50,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -256,7 +274,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="/agents">Agents</a>

--- a/templates/test_case_detail.html
+++ b/templates/test_case_detail.html
@@ -259,7 +259,9 @@
                 <span>LLM Replay System</span>
             </a>
             <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/test-cases">Test Cases</a>
+                <a class="nav-link" href="/agents">Agents</a>
+                <a class="nav-link active" href="/test-cases">Test Cases</a>
+                <a class="nav-link" href="/regression-tests">Regression Tests</a>
                 <a class="nav-link" href="/test-execution">Execute Tests</a>
                 <a class="nav-link" href="/test-logs">Test Logs</a>
             </div>
@@ -416,6 +418,28 @@
         }
 
         function displayTestCaseDetails(testCase) {
+            const agentName = testCase.agent ? testCase.agent.name : null;
+            const agentId = testCase.agent_id || '';
+            const agentBadge = agentName
+                ? `<span class="badge bg-primary">${escapeHtml(agentName)}</span>`
+                : '<span class="text-muted">Unknown agent</span>';
+            const agentIdHtml = agentId ? `<small class="text-muted ms-2">${escapeHtml(agentId)}</small>` : '';
+            const agentLinks = agentId
+                ? `
+                    <div class="mt-2 small">
+                        <a href="/test-cases?agentId=${encodeURIComponent(agentId)}" class="text-decoration-none" target="_blank">
+                            View test cases for this agent
+                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                        </a>
+                        <span class="text-muted mx-1">•</span>
+                        <a href="/agents" class="text-decoration-none" target="_blank">
+                            Manage agents
+                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                        </a>
+                    </div>
+                `
+                : '';
+
             const detailsHtml = `
                 <div class="row">
                     <!-- Left Column -->
@@ -440,6 +464,18 @@
                                         <td>${escapeHtml(testCase.description || 'No description provided')}</td>
                                     </tr>
                                     <tr>
+                                        <td>Agent:</td>
+                                        <td>
+                                            <div class="d-flex flex-column">
+                                                <div>
+                                                    ${agentBadge}
+                                                    ${agentIdHtml}
+                                                </div>
+                                                ${agentLinks}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    <tr>
                                         <td>Created At:</td>
                                         <td>${formatDate(testCase.created_at)}</td>
                                     </tr>
@@ -453,7 +489,7 @@
                                     </tr>
                                     <tr>
                                         <td>Model Settings:</td>
-                                        <td>${testCase.model_settings !== null && testCase.model_settings !== undefined ? `<pre class="bg-light p-2 rounded"><code>${JSON.stringify(testCase.model_settings, null, 2)}</code></pre>` : '<span class="text-muted">Not specified</span>'}</td>
+                                        <td>${testCase.model_settings !== null && testCase.model_settings !== undefined ? `<pre class="bg-light p-2 rounded"><code>${escapeHtml(JSON.stringify(testCase.model_settings, null, 2))}</code></pre>` : '<span class="text-muted">Not specified</span>'}</td>
                                     </tr>
                                 </table>
                             </div>

--- a/templates/test_cases.html
+++ b/templates/test_cases.html
@@ -50,6 +50,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -358,7 +376,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="/agents">Agents</a>

--- a/templates/test_cases.html
+++ b/templates/test_cases.html
@@ -399,16 +399,19 @@
         <div class="card mb-4">
             <div class="card-body py-3">
                 <div class="d-flex flex-wrap align-items-center gap-3">
-                    <span class="text-muted fw-medium me-2">
+                    <span class="text-muted fw-medium me-2 d-flex align-items-center">
                         <i class="fas fa-filter me-2"></i>Filters:
                     </span>
-                    <select class="form-select form-select-sm" id="agentFilter" style="width: 220px;">
+                    <select class="form-select form-select-sm" id="agentFilter" style="width: 220px; flex: 0 0 auto;">
                         <option value="">All agents</option>
                     </select>
-                    <div class="search-container ms-auto" style="min-width: 260px;">
+                    <div class="search-container" style="flex: 1 1 260px; max-width: 420px;">
                         <i class="fas fa-search search-icon"></i>
                         <input type="text" class="form-control" id="searchInput" placeholder="Search test case by name">
                     </div>
+                    <button class="btn btn-outline-secondary btn-sm ms-auto" id="clearFiltersBtn">
+                        <i class="fas fa-eraser me-1"></i>Clear
+                    </button>
                 </div>
             </div>
         </div>

--- a/templates/test_cases.html
+++ b/templates/test_cases.html
@@ -372,11 +372,21 @@
 
     <div class="container py-4">
         <!-- Header -->
-        <div class="page-header">
-            <h1 class="page-title">
-                <i class="fas fa-list-alt me-3"></i>Test Cases
-            </h1>
-            <p class="page-subtitle">Manage your LLM test cases and raw data</p>
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
+            <div class="mb-3 mb-lg-0">
+                <h1 class="page-title mb-1">
+                    <i class="fas fa-list-alt me-3"></i>Test Cases
+                </h1>
+                <p class="page-subtitle mb-0">Manage your LLM test cases and raw data</p>
+            </div>
+            <div class="d-flex align-items-center gap-2">
+                <button class="btn btn-outline-primary" onclick="loadTestCases()">
+                    <i class="fas fa-refresh me-2"></i>Refresh
+                </button>
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createTestCaseModal">
+                    <i class="fas fa-plus me-2"></i>Create Test Case
+                </button>
+            </div>
         </div>
 
         <div id="agentWarning" class="alert alert-warning d-none" role="alert">
@@ -386,26 +396,20 @@
         </div>
 
         <!-- Controls -->
-        <div class="row mb-4 gy-3 align-items-center">
-            <div class="col-lg-4 col-md-6">
-                <div class="search-container">
-                    <i class="fas fa-search search-icon"></i>
-                    <input type="text" class="form-control" id="searchInput" placeholder="Search test case by name">
+        <div class="card mb-4">
+            <div class="card-body py-3">
+                <div class="d-flex flex-wrap align-items-center gap-3">
+                    <span class="text-muted fw-medium me-2">
+                        <i class="fas fa-filter me-2"></i>Filters:
+                    </span>
+                    <select class="form-select form-select-sm" id="agentFilter" style="width: 220px;">
+                        <option value="">All agents</option>
+                    </select>
+                    <div class="search-container ms-auto" style="min-width: 260px;">
+                        <i class="fas fa-search search-icon"></i>
+                        <input type="text" class="form-control" id="searchInput" placeholder="Search test case by name">
+                    </div>
                 </div>
-            </div>
-            <div class="col-lg-4 col-md-6">
-                <label for="agentFilter" class="form-label mb-1 text-muted fw-medium">Filter by Agent</label>
-                <select class="form-select" id="agentFilter">
-                    <option value="">All agents</option>
-                </select>
-            </div>
-            <div class="col-lg-4 text-md-end">
-                <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#createTestCaseModal">
-                    <i class="fas fa-plus me-2"></i>Create Test Case
-                </button>
-                <button class="btn btn-outline-primary" onclick="loadTestCases()">
-                    <i class="fas fa-refresh me-2"></i>Refresh
-                </button>
             </div>
         </div>
 

--- a/templates/test_cases.html
+++ b/templates/test_cases.html
@@ -361,7 +361,9 @@
                 <span>LLM Replay System</span>
             </a>
             <div class="navbar-nav ms-auto">
+                <a class="nav-link" href="/agents">Agents</a>
                 <a class="nav-link active" href="/test-cases">Test Cases</a>
+                <a class="nav-link" href="/regression-tests">Regression Tests</a>
                 <a class="nav-link" href="/test-execution">Execute Tests</a>
                 <a class="nav-link" href="/test-logs">Test Logs</a>
             </div>
@@ -377,15 +379,27 @@
             <p class="page-subtitle">Manage your LLM test cases and raw data</p>
         </div>
 
+        <div id="agentWarning" class="alert alert-warning d-none" role="alert">
+            <i class="fas fa-circle-exclamation me-2"></i>
+            <span>No active agents found. Create an agent first so new test cases can be assigned correctly.</span>
+            <a href="/agents" class="alert-link ms-1">Go to Agents</a>
+        </div>
+
         <!-- Controls -->
-        <div class="row mb-4 align-items-center">
-            <div class="col-md-6">
+        <div class="row mb-4 gy-3 align-items-center">
+            <div class="col-lg-4 col-md-6">
                 <div class="search-container">
                     <i class="fas fa-search search-icon"></i>
                     <input type="text" class="form-control" id="searchInput" placeholder="Search test case by name">
                 </div>
             </div>
-            <div class="col-md-6 text-end">
+            <div class="col-lg-4 col-md-6">
+                <label for="agentFilter" class="form-label mb-1 text-muted fw-medium">Filter by Agent</label>
+                <select class="form-select" id="agentFilter">
+                    <option value="">All agents</option>
+                </select>
+            </div>
+            <div class="col-lg-4 text-md-end">
                 <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#createTestCaseModal">
                     <i class="fas fa-plus me-2"></i>Create Test Case
                 </button>
@@ -400,11 +414,12 @@
             <table class="table table-hover mb-0" id="testCasesTable">
                 <thead>
                     <tr>
-                        <th style="width: 25%">Name</th>
-                        <th style="width: 15%">Model</th>
-                        <th style="width: 30%">System Prompt</th>
-                        <th style="width: 15%">Created</th>
-                        <th style="width: 15%" class="text-end">Actions</th>
+                        <th style="width: 24%">Name</th>
+                        <th style="width: 18%">Agent</th>
+                        <th style="width: 16%">Model</th>
+                        <th style="width: 24%">System Prompt</th>
+                        <th style="width: 10%">Created</th>
+                        <th style="width: 8%" class="text-end">Actions</th>
                     </tr>
                 </thead>
                 <tbody id="testCasesList">
@@ -429,10 +444,15 @@
                 <i class="fas fa-robot"></i>
             </div>
             <h3>No test cases found</h3>
-            <p>Create your first test case to get started</p>
-            <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createTestCaseModal">
-                <i class="fas fa-plus me-2"></i>Create Test Case
-            </button>
+            <p>Create your first test case to get started or import existing conversations.</p>
+            <div class="d-flex justify-content-center gap-3 flex-wrap">
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createTestCaseModal">
+                    <i class="fas fa-plus me-2"></i>Create Test Case
+                </button>
+                <a class="btn btn-outline-primary" href="/agents">
+                    <i class="fas fa-user-astronaut me-2"></i>Manage Agents
+                </a>
+            </div>
         </div>
     </div>
 
@@ -453,6 +473,13 @@
                         <div class="mb-3">
                             <label for="testCaseDescription" class="form-label">Description</label>
                             <textarea class="form-control" id="testCaseDescription" rows="3"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="createTestCaseAgent" class="form-label">Agent *</label>
+                            <select class="form-select" id="createTestCaseAgent" required>
+                                <option value="">Select an agent...</option>
+                            </select>
+                            <div class="form-text">Test cases inherit defaults and ownership from the selected agent.</div>
                         </div>
                         <div class="mb-3">
                             <label for="rawData" class="form-label">Raw Data (JSON) *</label>
@@ -492,10 +519,16 @@
                             <textarea class="form-control" id="editTestCaseDescription" rows="4"
                                 placeholder="Enter a description for this test case..."></textarea>
                         </div>
+                        <div class="mb-3">
+                            <label for="editTestCaseAgent" class="form-label">Agent *</label>
+                            <select class="form-select" id="editTestCaseAgent" required>
+                                <option value="">Select an agent...</option>
+                            </select>
+                        </div>
                         <div class="alert alert-info">
                             <i class="fas fa-info-circle me-2"></i>
-                            <strong>Note:</strong> Only the name and description can be modified. Other test case
-                            properties (system prompt, user message, etc.) are read-only.
+                            <strong>Note:</strong> Update the agent to hand off this test case to a different model
+                            configuration. Other test case properties (system prompt, user message, etc.) remain read-only.
                         </div>
                     </form>
                 </div>

--- a/templates/test_cases.html
+++ b/templates/test_cases.html
@@ -1,396 +1,294 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Test Cases - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
-        }
+{% block page_title %}Test Cases - LLM Replay System{% endblock %}
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
+{% block extra_css %}
+<style>
+    /* Page Header */
+    .page-header {
+        margin-bottom: 2rem;
+    }
 
-        /* Navigation Styles */
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
 
-        .navbar-brand i {
-            color: var(--primary-color);
+    /* Card Styles */
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
+
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    /* Button Styles */
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
+
+    .btn-outline-primary {
+        color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    .btn-outline-primary:hover {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+    }
+
+    /* Search Input */
+    .search-container {
+        position: relative;
+        max-width: 400px;
+    }
+
+    .search-container .form-control {
+        padding-left: 2.75rem;
+        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        background-color: var(--card-background);
+        transition: all 0.2s ease;
+    }
+
+    .search-container .form-control:focus {
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+
+    .search-container .search-icon {
+        position: absolute;
+        left: 0.75rem;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--text-muted);
+        z-index: 1;
+        pointer-events: none;
+    }
+
+    /* Table Styles */
+    .table-container {
+        background: var(--card-background);
+        border-radius: 0.75rem;
+        overflow: hidden;
+        border: 1px solid var(--border-color);
+    }
+
+    .table {
+        margin-bottom: 0;
+    }
+
+    .table th {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 1rem;
+        font-size: 0.875rem;
+    }
+
+    .table td {
+        padding: 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+
+    .table tbody tr {
+        transition: background-color 0.2s ease;
+    }
+
+    .table tbody tr:hover {
+        background-color: #f8fafc;
+    }
+
+    .table tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    /* Badge Styles */
+    .badge {
+        font-weight: 500;
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+    }
+
+    .badge.bg-primary {
+        background-color: var(--primary-color) !important;
+    }
+
+    .badge.bg-info {
+        background-color: var(--success-color) !important;
+    }
+
+    /* Action Buttons */
+    .btn-group .btn {
+        border-radius: 0.375rem !important;
+        margin-right: 0.25rem;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.875rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-group .btn:last-child {
+        margin-right: 0;
+    }
+
+    .btn-outline-primary:hover,
+    .btn-outline-secondary:hover,
+    .btn-outline-success:hover,
+    .btn-outline-danger:hover {
+        transform: translateY(-1px);
+    }
+
+    /* Empty State */
+    .empty-state {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: var(--text-secondary);
+    }
+
+    .empty-state .empty-icon {
+        width: 4rem;
+        height: 4rem;
+        background-color: #f1f5f9;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 auto 1.5rem;
+    }
+
+    .empty-state .empty-icon i {
+        font-size: 1.5rem;
+        color: var(--text-muted);
+    }
+
+    .empty-state h3 {
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .empty-state p {
+        color: var(--text-secondary);
+        margin-bottom: 1.5rem;
+    }
+
+    /* Loading State */
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
+
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
+
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    /* Modal Enhancements */
+    .modal-content {
+        border-radius: 0.75rem;
+        border: 1px solid var(--border-color);
+        box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+    }
+
+    .modal-header {
+        border-bottom: 1px solid var(--border-color);
+        padding: 1.5rem;
+    }
+
+    .modal-title {
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .modal-body {
+        padding: 1.5rem;
+    }
+
+    .modal-footer {
+        border-top: 1px solid var(--border-color);
+        padding: 1.5rem;
+    }
+
+    /* Form Enhancements */
+    .form-label {
+        font-weight: 500;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .form-control,
+    .form-select {
+        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        padding: 0.625rem 0.75rem;
+        transition: all 0.2s ease;
+    }
+
+    .form-control:focus,
+    .form-select:focus {
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+
+    .form-text {
+        color: var(--text-muted);
+        font-size: 0.875rem;
+    }
+
+    /* Responsive Improvements */
+    @media (max-width: 768px) {
+        .page-title {
             font-size: 1.5rem;
         }
 
-        .brand-text {
-            display: flex;
+        .btn-group {
             flex-direction: column;
+            gap: 0.25rem;
         }
 
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
-
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
-
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
-
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
-
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
-
-        /* Page Header */
-        .page-header {
-            margin-bottom: 2rem;
-        }
-
-        .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
-
-        /* Card Styles */
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
-
-        .card:hover {
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        }
-
-        /* Button Styles */
-        .btn-primary {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            padding: 0.625rem 1.25rem;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-primary:hover {
-            background-color: var(--primary-hover);
-            border-color: var(--primary-hover);
-            transform: translateY(-1px);
-        }
-
-        .btn-outline-primary {
-            color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
-
-        .btn-outline-primary:hover {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-        }
-
-        /* Search Input */
-        .search-container {
-            position: relative;
-            max-width: 400px;
-        }
-
-        .search-container .form-control {
-            padding-left: 2.75rem;
-            border-radius: 0.5rem;
-            border: 1px solid var(--border-color);
-            background-color: var(--card-background);
-            transition: all 0.2s ease;
-        }
-
-        .search-container .form-control:focus {
-            border-color: var(--primary-color);
-            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-        }
-
-        .search-container .search-icon {
-            position: absolute;
-            left: 0.75rem;
-            top: 50%;
-            transform: translateY(-50%);
-            color: var(--text-muted);
-            z-index: 1;
-            pointer-events: none;
-        }
-
-        /* Table Styles */
-        .table-container {
-            background: var(--card-background);
-            border-radius: 0.75rem;
-            overflow: hidden;
-            border: 1px solid var(--border-color);
-        }
-
-        .table {
-            margin-bottom: 0;
-        }
-
-        .table th {
-            background-color: #f8fafc;
-            border-bottom: 1px solid var(--border-color);
-            font-weight: 600;
-            color: var(--text-primary);
-            padding: 1rem;
-            font-size: 0.875rem;
-        }
-
-        .table td {
-            padding: 1rem;
-            border-bottom: 1px solid #f1f5f9;
-            vertical-align: middle;
-        }
-
-        .table tbody tr {
-            transition: background-color 0.2s ease;
-        }
-
-        .table tbody tr:hover {
-            background-color: #f8fafc;
-        }
-
-        .table tbody tr:last-child td {
-            border-bottom: none;
-        }
-
-        /* Badge Styles */
-        .badge {
-            font-weight: 500;
-            padding: 0.375rem 0.75rem;
-            border-radius: 0.375rem;
-            font-size: 0.75rem;
-        }
-
-        .badge.bg-primary {
-            background-color: var(--primary-color) !important;
-        }
-
-        .badge.bg-info {
-            background-color: var(--success-color) !important;
-        }
-
-        /* Action Buttons */
         .btn-group .btn {
-            border-radius: 0.375rem !important;
-            margin-right: 0.25rem;
-            padding: 0.375rem 0.75rem;
-            font-size: 0.875rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-group .btn:last-child {
             margin-right: 0;
         }
+    }
+</style>
+{% endblock %}
 
-        .btn-outline-primary:hover,
-        .btn-outline-secondary:hover,
-        .btn-outline-success:hover,
-        .btn-outline-danger:hover {
-            transform: translateY(-1px);
-        }
-
-        /* Empty State */
-        .empty-state {
-            text-align: center;
-            padding: 4rem 2rem;
-            color: var(--text-secondary);
-        }
-
-        .empty-state .empty-icon {
-            width: 4rem;
-            height: 4rem;
-            background-color: #f1f5f9;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 0 auto 1.5rem;
-        }
-
-        .empty-state .empty-icon i {
-            font-size: 1.5rem;
-            color: var(--text-muted);
-        }
-
-        .empty-state h3 {
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .empty-state p {
-            color: var(--text-secondary);
-            margin-bottom: 1.5rem;
-        }
-
-        /* Loading State */
-        .loading-state {
-            text-align: center;
-            padding: 3rem 2rem;
-        }
-
-        .loading-spinner {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            color: var(--primary-color);
-        }
-
-        .loading-spinner .spinner-border {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        /* Modal Enhancements */
-        .modal-content {
-            border-radius: 0.75rem;
-            border: 1px solid var(--border-color);
-            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
-        }
-
-        .modal-header {
-            border-bottom: 1px solid var(--border-color);
-            padding: 1.5rem;
-        }
-
-        .modal-title {
-            font-weight: 600;
-            color: var(--text-primary);
-        }
-
-        .modal-body {
-            padding: 1.5rem;
-        }
-
-        .modal-footer {
-            border-top: 1px solid var(--border-color);
-            padding: 1.5rem;
-        }
-
-        /* Form Enhancements */
-        .form-label {
-            font-weight: 500;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .form-control,
-        .form-select {
-            border-radius: 0.5rem;
-            border: 1px solid var(--border-color);
-            padding: 0.625rem 0.75rem;
-            transition: all 0.2s ease;
-        }
-
-        .form-control:focus,
-        .form-select:focus {
-            border-color: var(--primary-color);
-            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-        }
-
-        .form-text {
-            color: var(--text-muted);
-            font-size: 0.875rem;
-        }
-
-        /* Responsive Improvements */
-        @media (max-width: 768px) {
-            .page-title {
-                font-size: 1.5rem;
-            }
-
-            .btn-group {
-                flex-direction: column;
-                gap: 0.25rem;
-            }
-
-            .btn-group .btn {
-                margin-right: 0;
-            }
-        }
-    </style>
-</head>
-
-<body>
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/agents">Agents</a>
-                <a class="nav-link active" href="/test-cases">Test Cases</a>
-                <a class="nav-link" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <!-- Header -->
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
@@ -629,9 +527,8 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script src="/static/js/test-cases.js?v={{ static_asset_version }}"></script>
-</body>
-
-</html>
+{% endblock %}

--- a/templates/test_execution.html
+++ b/templates/test_execution.html
@@ -1,347 +1,245 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Test Execution - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
-        }
+{% block page_title %}Test Execution - LLM Replay System{% endblock %}
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
+{% block extra_css %}
+<style>
+    /* Page Header */
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        /* Navigation Styles */
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
 
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
+    /* Card Styles */
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
 
-        .navbar-brand i {
-            color: var(--primary-color);
-            font-size: 1.5rem;
-        }
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
 
-        .brand-text {
-            display: flex;
-            flex-direction: column;
-        }
+    .card-header {
+        background: transparent;
+        border-bottom: 1px solid var(--border-color);
+        padding: 1.5rem;
+    }
 
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
+    .card-body {
+        padding: 1.5rem;
+    }
 
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
+    .card-title {
+        font-weight: 600;
+        color: var(--text-primary);
+        font-size: 1.125rem;
+    }
 
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
+    /* Button Styles */
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
 
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
 
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
+    .btn-outline-primary {
+        color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
 
-        /* Page Header */
-        .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
+    .btn-outline-primary:hover {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+    }
 
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
+    .btn-success {
+        background-color: var(--success-color);
+        border-color: var(--success-color);
+    }
 
-        /* Card Styles */
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
+    .btn-success:hover {
+        background-color: #047857;
+        border-color: #047857;
+        transform: translateY(-1px);
+    }
 
-        .card:hover {
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        }
+    /* Form Styles */
+    .form-label {
+        font-weight: 500;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        .card-header {
-            background: transparent;
-            border-bottom: 1px solid var(--border-color);
-            padding: 1.5rem;
-        }
+    .form-control,
+    .form-select {
+        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        padding: 0.625rem 0.75rem;
+        transition: all 0.2s ease;
+        background-color: var(--card-background);
+    }
 
-        .card-body {
-            padding: 1.5rem;
-        }
+    .form-control:focus,
+    .form-select:focus {
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
 
-        .card-title {
-            font-weight: 600;
-            color: var(--text-primary);
-            font-size: 1.125rem;
-        }
+    .prompt-editor {
+        font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+        font-size: 0.875rem;
+        line-height: 1.5;
+    }
 
-        /* Button Styles */
-        .btn-primary {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            padding: 0.625rem 1.25rem;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
+    /* Execution Panel */
+    .execution-panel {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+    }
 
-        .btn-primary:hover {
-            background-color: var(--primary-hover);
-            border-color: var(--primary-hover);
-            transform: translateY(-1px);
-        }
+    .result-panel {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        min-height: 600px;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+    }
 
-        .btn-outline-primary {
-            color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
+    .llm-response-container {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
 
-        .btn-outline-primary:hover {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-        }
+    .llm-response-content {
+        flex: 1;
+        overflow-y: auto;
+        background-color: #f8f9fa;
+        padding: 1rem;
+        border-radius: 0.375rem;
+        font-family: 'Courier New', monospace;
+        font-size: 0.9em;
+        white-space: pre-wrap;
+        min-height: 200px;
+    }
 
-        .btn-success {
-            background-color: var(--success-color);
-            border-color: var(--success-color);
-        }
+    /* Status Styles */
+    .status-success {
+        color: var(--success-color);
+    }
 
-        .btn-success:hover {
-            background-color: #047857;
-            border-color: #047857;
-            transform: translateY(-1px);
-        }
+    .status-failed {
+        color: var(--danger-color);
+    }
 
-        /* Form Styles */
-        .form-label {
-            font-weight: 500;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
+    .status-running {
+        color: var(--primary-color);
+    }
 
-        .form-control,
-        .form-select {
-            border-radius: 0.5rem;
-            border: 1px solid var(--border-color);
-            padding: 0.625rem 0.75rem;
-            transition: all 0.2s ease;
-            background-color: var(--card-background);
-        }
+    /* Badge Styles */
+    .badge {
+        font-weight: 500;
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+    }
 
-        .form-control:focus,
-        .form-select:focus {
-            border-color: var(--primary-color);
-            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-        }
+    .badge.bg-success {
+        background-color: var(--success-color) !important;
+    }
 
-        .prompt-editor {
-            font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
-            font-size: 0.875rem;
-            line-height: 1.5;
-        }
+    .badge.bg-danger {
+        background-color: var(--danger-color) !important;
+    }
 
-        /* Execution Panel */
-        .execution-panel {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            padding: 1.5rem;
-        }
+    .badge.bg-primary {
+        background-color: var(--primary-color) !important;
+    }
 
-        .result-panel {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            min-height: 600px;
-            padding: 1.5rem;
-            display: flex;
-            flex-direction: column;
-        }
+    /* Tools Container */
+    #toolsContainer {
+        max-height: 300px;
+        overflow-y: auto;
+    }
 
-        .llm-response-container {
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            min-height: 0;
-        }
+    /* Model Name History Dropdown */
+    .model-history-dropdown {
+        position: absolute;
+        top: calc(100% + 2px);
+        left: 0;
+        width: 100%;
+        max-height: 200px;
+        overflow-y: auto;
+        z-index: 1000;
+        border: 1px solid #dee2e6;
+        border-radius: 0.375rem;
+        background-color: white;
+        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+        display: none;
+    }
 
-        .llm-response-content {
-            flex: 1;
-            overflow-y: auto;
-            background-color: #f8f9fa;
-            padding: 1rem;
-            border-radius: 0.375rem;
-            font-family: 'Courier New', monospace;
-            font-size: 0.9em;
-            white-space: pre-wrap;
-            min-height: 200px;
-        }
+    .model-history-dropdown.show {
+        display: block;
+    }
 
-        /* Status Styles */
-        .status-success {
-            color: var(--success-color);
-        }
+    .model-history-dropdown .dropdown-item {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #f8f9fa;
+        transition: background-color 0.15s ease-in-out;
+        cursor: pointer;
+    }
 
-        .status-failed {
-            color: var(--danger-color);
-        }
+    .model-history-dropdown .dropdown-item:last-child {
+        border-bottom: none;
+    }
 
-        .status-running {
-            color: var(--primary-color);
-        }
+    .model-history-dropdown .dropdown-item:hover {
+        background-color: #f8f9fa;
+    }
 
-        /* Badge Styles */
-        .badge {
-            font-weight: 500;
-            padding: 0.375rem 0.75rem;
-            border-radius: 0.375rem;
-            font-size: 0.75rem;
-        }
+    .model-history-dropdown .btn-outline-danger {
+        border-color: #dc3545;
+        color: #dc3545;
+        opacity: 0.7;
+        transition: all 0.15s ease-in-out;
+    }
 
-        .badge.bg-success {
-            background-color: var(--success-color) !important;
-        }
+    .model-history-dropdown .btn-outline-danger:hover {
+        background-color: #dc3545;
+        color: white;
+        opacity: 1;
+    }
+</style>
+{% endblock %}
 
-        .badge.bg-danger {
-            background-color: var(--danger-color) !important;
-        }
-
-        .badge.bg-primary {
-            background-color: var(--primary-color) !important;
-        }
-
-        /* Tools Container */
-        #toolsContainer {
-            max-height: 300px;
-            overflow-y: auto;
-        }
-
-        /* Model Name History Dropdown */
-        .model-history-dropdown {
-            position: absolute;
-            top: calc(100% + 2px);
-            left: 0;
-            width: 100%;
-            max-height: 200px;
-            overflow-y: auto;
-            z-index: 1000;
-            border: 1px solid #dee2e6;
-            border-radius: 0.375rem;
-            background-color: white;
-            box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-            display: none;
-        }
-
-        .model-history-dropdown.show {
-            display: block;
-        }
-
-        .model-history-dropdown .dropdown-item {
-            padding: 0.5rem 0.75rem;
-            border-bottom: 1px solid #f8f9fa;
-            transition: background-color 0.15s ease-in-out;
-            cursor: pointer;
-        }
-
-        .model-history-dropdown .dropdown-item:last-child {
-            border-bottom: none;
-        }
-
-        .model-history-dropdown .dropdown-item:hover {
-            background-color: #f8f9fa;
-        }
-
-        .model-history-dropdown .btn-outline-danger {
-            border-color: #dc3545;
-            color: #dc3545;
-            opacity: 0.7;
-            transition: all 0.15s ease-in-out;
-        }
-
-        .model-history-dropdown .btn-outline-danger:hover {
-            background-color: #dc3545;
-            color: white;
-            opacity: 1;
-        }
-    </style>
-</head>
-
-<body>
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/agents">Agents</a>
-                <a class="nav-link" href="/test-cases">Test Cases</a>
-                <a class="nav-link" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link active" href="/test-execution">Execute Tests</a>
-                <a class="nav-link" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <!-- Header -->
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
@@ -545,22 +443,21 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script src="/static/js/test-execution.js?v={{ static_asset_version }}"></script>
 
-    <script>
-        // Handle Model Settings collapse icon rotation
-        document.getElementById('modelSettingsCollapse').addEventListener('show.bs.collapse', function () {
-            document.getElementById('modelSettingsChevron').classList.remove('fa-chevron-right');
-            document.getElementById('modelSettingsChevron').classList.add('fa-chevron-down');
-        });
+        <script>
+            // Handle Model Settings collapse icon rotation
+            document.getElementById('modelSettingsCollapse').addEventListener('show.bs.collapse', function () {
+                document.getElementById('modelSettingsChevron').classList.remove('fa-chevron-right');
+                document.getElementById('modelSettingsChevron').classList.add('fa-chevron-down');
+            });
 
-        document.getElementById('modelSettingsCollapse').addEventListener('hide.bs.collapse', function () {
-            document.getElementById('modelSettingsChevron').classList.remove('fa-chevron-down');
-            document.getElementById('modelSettingsChevron').classList.add('fa-chevron-right');
-        });
-    </script>
-</body>
-
-</html>
+            document.getElementById('modelSettingsCollapse').addEventListener('hide.bs.collapse', function () {
+                document.getElementById('modelSettingsChevron').classList.remove('fa-chevron-down');
+                document.getElementById('modelSettingsChevron').classList.add('fa-chevron-right');
+            });
+        </script>
+{% endblock %}

--- a/templates/test_execution.html
+++ b/templates/test_execution.html
@@ -312,7 +312,9 @@
                 <span>LLM Replay System</span>
             </a>
             <div class="navbar-nav ms-auto">
+                <a class="nav-link" href="/agents">Agents</a>
                 <a class="nav-link" href="/test-cases">Test Cases</a>
+                <a class="nav-link" href="/regression-tests">Regression Tests</a>
                 <a class="nav-link active" href="/test-execution">Execute Tests</a>
                 <a class="nav-link" href="/test-logs">Test Logs</a>
             </div>
@@ -328,28 +330,44 @@
             <p class="page-subtitle">Execute and test your LLM configurations</p>
         </div>
 
+        <div id="executionAgentWarning" class="alert alert-warning d-none" role="alert">
+            <i class="fas fa-circle-exclamation me-2"></i>
+            <span>No active agents available. Configure an agent before executing test cases.</span>
+            <a href="/agents" class="alert-link ms-1">Manage Agents</a>
+        </div>
+
         <!-- Test Case Selection - Full Width -->
         <div class="row mb-3">
             <div class="col-12">
                 <div class="card">
                     <div class="card-header">
-                        <div class="row align-items-center">
-                            <div class="col-md-4">
+                        <div class="row align-items-center g-3">
+                            <div class="col-xl-3 col-lg-4">
+                                <label for="agentSelect" class="form-label text-muted small mb-1">Agent</label>
+                                <select class="form-select" id="agentSelect">
+                                    <option value="">All agents</option>
+                                </select>
+                            </div>
+                            <div class="col-xl-5 col-lg-4">
+                                <label for="testCaseSelect" class="form-label text-muted small mb-1">Test Case</label>
                                 <select class="form-select" id="testCaseSelect">
                                     <option value="">Select a test case...</option>
                                 </select>
+                                <div class="form-text" id="selectedTestCaseAgent">Select a test case to preview its agent.</div>
                             </div>
-                            <div class="col-md-8 text-end">
+                            <div class="col-xl-4 col-lg-4 text-lg-end">
                                 <!-- Execute Controls -->
-                                <button class="btn btn-success me-2" id="executeBtn" onclick="executeTest()" disabled>
-                                    <i class="fas fa-play me-1"></i>Execute Test
-                                </button>
-                                <button class="btn btn-outline-primary btn-sm me-2" onclick="resetToOriginal()">
-                                    <i class="fas fa-undo me-1"></i>Reset to Original
-                                </button>
-                                <button class="btn btn-outline-secondary btn-sm" onclick="viewTestLogs()">
-                                    <i class="fas fa-history me-1"></i>View Test Logs
-                                </button>
+                                <div class="d-flex flex-wrap justify-content-lg-end gap-2">
+                                    <button class="btn btn-success" id="executeBtn" onclick="executeTest()" disabled>
+                                        <i class="fas fa-play me-1"></i>Execute Test
+                                    </button>
+                                    <button class="btn btn-outline-primary btn-sm" onclick="resetToOriginal()">
+                                        <i class="fas fa-undo me-1"></i>Reset to Original
+                                    </button>
+                                    <button class="btn btn-outline-secondary btn-sm" onclick="viewTestLogs()">
+                                        <i class="fas fa-history me-1"></i>View Test Logs
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/templates/test_execution.html
+++ b/templates/test_execution.html
@@ -50,6 +50,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -309,7 +327,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="/agents">Agents</a>
@@ -323,11 +344,25 @@
 
     <div class="container py-4">
         <!-- Header -->
-        <div class="mb-4">
-            <h1 class="page-title">
-                <i class="fas fa-play me-3"></i>Test Execution
-            </h1>
-            <p class="page-subtitle">Execute and test your LLM configurations</p>
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
+            <div class="mb-3 mb-lg-0">
+                <h1 class="page-title">
+                    <i class="fas fa-play me-3"></i>Test Execution
+                </h1>
+                <p class="page-subtitle mb-0">Execute and test your LLM configurations</p>
+            </div>
+            <div class="d-flex align-items-center gap-2">
+                <!-- Execute Controls -->
+                <button class="btn btn-success" id="executeBtn" onclick="executeTest()" disabled>
+                    <i class="fas fa-play me-2"></i>Execute Test
+                </button>
+                <button class="btn btn-outline-primary" onclick="resetToOriginal()">
+                    <i class="fas fa-undo me-2"></i>Reset to Original
+                </button>
+                <button class="btn btn-outline-secondary" onclick="viewTestLogs()">
+                    <i class="fas fa-history me-2"></i>View Test Logs
+                </button>
+            </div>
         </div>
 
         <div id="executionAgentWarning" class="alert alert-warning d-none" role="alert">
@@ -336,40 +371,22 @@
             <a href="/agents" class="alert-link ms-1">Manage Agents</a>
         </div>
 
-        <!-- Test Case Selection - Full Width -->
-        <div class="row mb-3">
-            <div class="col-12">
-                <div class="card">
-                    <div class="card-header">
-                        <div class="row align-items-center g-3">
-                            <div class="col-xl-3 col-lg-4">
-                                <label for="agentSelect" class="form-label text-muted small mb-1">Agent</label>
-                                <select class="form-select" id="agentSelect">
-                                    <option value="">All agents</option>
-                                </select>
-                            </div>
-                            <div class="col-xl-5 col-lg-4">
-                                <label for="testCaseSelect" class="form-label text-muted small mb-1">Test Case</label>
-                                <select class="form-select" id="testCaseSelect">
-                                    <option value="">Select a test case...</option>
-                                </select>
-                                <div class="form-text" id="selectedTestCaseAgent">Select a test case to preview its agent.</div>
-                            </div>
-                            <div class="col-xl-4 col-lg-4 text-lg-end">
-                                <!-- Execute Controls -->
-                                <div class="d-flex flex-wrap justify-content-lg-end gap-2">
-                                    <button class="btn btn-success" id="executeBtn" onclick="executeTest()" disabled>
-                                        <i class="fas fa-play me-1"></i>Execute Test
-                                    </button>
-                                    <button class="btn btn-outline-primary btn-sm" onclick="resetToOriginal()">
-                                        <i class="fas fa-undo me-1"></i>Reset to Original
-                                    </button>
-                                    <button class="btn btn-outline-secondary btn-sm" onclick="viewTestLogs()">
-                                        <i class="fas fa-history me-1"></i>View Test Logs
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
+        <!-- Test Case Selection -->
+        <div class="card mb-4">
+            <div class="card-body py-3">
+                <div class="d-flex flex-wrap align-items-center gap-3">
+                    <span class="text-muted fw-medium me-2 d-flex align-items-center">
+                        <i class="fas fa-cog me-2"></i>Configuration:
+                    </span>
+                    <select class="form-select form-select-sm" id="agentSelect" style="width: 200px; flex: 0 0 auto;">
+                        <option value="">All agents</option>
+                    </select>
+                    <select class="form-select form-select-sm" id="testCaseSelect"
+                        style="flex: 1 1 300px; max-width: 500px;">
+                        <option value="">Select a test case...</option>
+                    </select>
+                    <div class="form-text ms-auto" id="selectedTestCaseAgent" style="flex: 0 0 auto; margin-bottom: 0;">
+                        Select a test case to preview its agent.
                     </div>
                 </div>
             </div>

--- a/templates/test_log_detail.html
+++ b/templates/test_log_detail.html
@@ -238,111 +238,111 @@
 {% endblock %}
 
 {% block content %}
-    <div class="container py-4">
-        <!-- Header with Action Buttons -->
-        <div class="page-header d-flex justify-content-between align-items-start">
-            <div>
-                <h1 class="page-title">
-                    <i class="fas fa-file-alt me-3"></i>Test Log Details
-                </h1>
-                <p class="page-subtitle">Detailed view of test execution log</p>
-            </div>
-            <div id="actionButtons" class="d-none">
-                <div class="d-flex gap-2">
-                    <button type="button" class="btn btn-success" onclick="reExecuteTest()">
-                        <i class="fas fa-redo me-2"></i>Re-execute Test
-                    </button>
-                    <button type="button" class="btn btn-outline-danger" onclick="deleteLog()">
-                        <i class="fas fa-trash me-2"></i>Delete Log
-                    </button>
-                </div>
-            </div>
+<div class="container py-4">
+    <!-- Header with Action Buttons -->
+    <div class="page-header d-flex justify-content-between align-items-start">
+        <div>
+            <h1 class="page-title">
+                <i class="fas fa-file-alt me-3"></i>Test Log Details
+            </h1>
+            <p class="page-subtitle">Detailed view of test execution log</p>
         </div>
-
-        <!-- Loading Spinner -->
-        <div id="loadingSpinner" class="loading-state">
-            <div class="loading-spinner">
-                <div class="spinner-border" role="status">
-                    <span class="visually-hidden">Loading...</span>
-                </div>
-                <span>Loading test log details...</span>
+        <div id="actionButtons" class="d-none">
+            <div class="d-flex gap-2">
+                <button type="button" class="btn btn-success" onclick="reExecuteTest()">
+                    <i class="fas fa-redo me-2"></i>Re-execute Test
+                </button>
+                <button type="button" class="btn btn-outline-danger" onclick="deleteLog()">
+                    <i class="fas fa-trash me-2"></i>Delete Log
+                </button>
             </div>
-        </div>
-
-        <!-- Error Message -->
-        <div id="errorMessage" class="error-message d-none">
-            <i class="fas fa-exclamation-triangle me-2"></i>
-            <span id="errorText"></span>
-        </div>
-
-        <!-- Log Details Content -->
-        <div id="logDetailsContent" class="d-none">
-            <!-- Content will be loaded here -->
         </div>
     </div>
+
+    <!-- Loading Spinner -->
+    <div id="loadingSpinner" class="loading-state">
+        <div class="loading-spinner">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+            <span>Loading test log details...</span>
+        </div>
+    </div>
+
+    <!-- Error Message -->
+    <div id="errorMessage" class="error-message d-none">
+        <i class="fas fa-exclamation-triangle me-2"></i>
+        <span id="errorText"></span>
+    </div>
+
+    <!-- Log Details Content -->
+    <div id="logDetailsContent" class="d-none">
+        <!-- Content will be loaded here -->
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}
-    <script>
-            // Get log ID from URL
-            const logId = '{{ log_id }}';
-            let currentLog = null;
-            let testCasesData = [];
-            let agentSummary = null;
-            let regressionSummary = null;
-            const agentCache = new Map();
-            const regressionCache = new Map();
+<script>
+    // Get log ID from URL
+    const logId = '{{ log_id }}';
+    let currentLog = null;
+    let testCasesData = [];
+    let agentSummary = null;
+    let regressionSummary = null;
+    const agentCache = new Map();
+    const regressionCache = new Map();
 
-            // Initialize page
-            document.addEventListener('DOMContentLoaded', async function () {
-                await loadTestCases();
-                await loadLogDetails();
-            });
+    // Initialize page
+    document.addEventListener('DOMContentLoaded', async function () {
+        await loadTestCases();
+        await loadLogDetails();
+    });
 
-            async function loadTestCases() {
-                try {
-                    const response = await fetch('/v1/api/test-cases/');
-                    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-                    testCasesData = await response.json();
-                } catch (error) {
-                    console.error('Error loading test cases:', error);
+    async function loadTestCases() {
+        try {
+            const response = await fetch('/v1/api/test-cases/');
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            testCasesData = await response.json();
+        } catch (error) {
+            console.error('Error loading test cases:', error);
+        }
+    }
+
+    async function loadLogDetails() {
+        try {
+            const response = await fetch(`/v1/api/test-logs/${logId}`);
+            if (!response.ok) {
+                if (response.status === 404) {
+                    throw new Error('Test log not found');
                 }
+                throw new Error(`HTTP error! status: ${response.status}`);
             }
 
-            async function loadLogDetails() {
-                try {
-                    const response = await fetch(`/v1/api/test-logs/${logId}`);
-                    if (!response.ok) {
-                        if (response.status === 404) {
-                            throw new Error('Test log not found');
-                        }
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
+            currentLog = await response.json();
 
-                    currentLog = await response.json();
-
-                    await loadAgentSummary(currentLog.agent_id);
-                    if (currentLog.regression_test_id) {
-                        await loadRegressionSummary(currentLog.regression_test_id);
-                    } else {
-                        regressionSummary = null;
-                    }
-
-                    displayLogDetails(currentLog);
-
-                } catch (error) {
-                    console.error('Error loading log details:', error);
-                    showError(error.message);
-                } finally {
-                    hideLoading();
-                }
+            await loadAgentSummary(currentLog.agent_id);
+            if (currentLog.regression_test_id) {
+                await loadRegressionSummary(currentLog.regression_test_id);
+            } else {
+                regressionSummary = null;
             }
 
-            function displayLogDetails(log) {
-                const testCase = findTestCaseById(log.test_case_id);
-                const responseTime = formatResponseTime(log.response_time_ms);
+            displayLogDetails(currentLog);
 
-                const detailsHtml = `
+        } catch (error) {
+            console.error('Error loading log details:', error);
+            showError(error.message);
+        } finally {
+            hideLoading();
+        }
+    }
+
+    function displayLogDetails(log) {
+        const testCase = findTestCaseById(log.test_case_id);
+        const responseTime = formatResponseTime(log.response_time_ms);
+
+        const detailsHtml = `
                     <div class="row">
                         <!-- Left Column -->
                         <div class="col-md-6">
@@ -385,19 +385,10 @@
                                         <tr>
                                             <td>Test Case:</td>
                                             <td>
-                                                <div>
-                                                    <a href="/test-cases/${log.test_case_id}" class="text-decoration-none" target="_blank">
-                                                        ${escapeHtml(testCase?.name || log.test_case_id)}
-                                                        <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                                                    </a>
-                                                </div>
-                                                ${testCase?.description ? `
-                                                    <div class="text-muted mt-1" style="font-size: 0.9em;">
-                                                        <span title="${escapeHtml(testCase.description)}" style="cursor: help;">
-                                                            ${truncateText(testCase.description, 100)}
-                                                        </span>
-                                                    </div>
-                                                ` : ''}
+                                                <a href="/test-cases/${log.test_case_id}" class="text-decoration-none" target="_blank">
+                                                    ${escapeHtml(testCase?.name || log.test_case_id)}
+                                                    <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                                                </a>
                                             </td>
                                         </tr>
                                         <tr>
@@ -480,9 +471,9 @@
                                 <div class="collapse" id="modelSettingsCollapse">
                                     <div class="card-body">
                                         ${log.model_settings !== null && log.model_settings !== undefined ?
-                        `<pre class="bg-light p-3 rounded mb-0"><code>${escapeHtml(JSON.stringify(log.model_settings, null, 2))}</code></pre>` :
-                        '<p class="text-muted mb-0">No model settings specified</p>'
-                    }
+                `<pre class="bg-light p-3 rounded mb-0"><code>${escapeHtml(JSON.stringify(log.model_settings, null, 2))}</code></pre>` :
+                '<p class="text-muted mb-0">No model settings specified</p>'
+            }
                                     </div>
                                 </div>
                             </div>
@@ -547,297 +538,263 @@
                     ` : ''}
                 `;
 
-                document.getElementById('logDetailsContent').innerHTML = detailsHtml;
-                document.getElementById('logDetailsContent').classList.remove('d-none');
-                document.getElementById('actionButtons').classList.remove('d-none');
+        document.getElementById('logDetailsContent').innerHTML = detailsHtml;
+        document.getElementById('logDetailsContent').classList.remove('d-none');
+        document.getElementById('actionButtons').classList.remove('d-none');
 
-                // Setup Model Settings collapse handlers
-                setupModelSettingsCollapse(log);
-            }
+        // Setup Model Settings collapse handlers
+        setupModelSettingsCollapse(log);
+    }
 
-            async function loadAgentSummary(agentId) {
-                if (!agentId) {
+    async function loadAgentSummary(agentId) {
+        if (!agentId) {
+            agentSummary = null;
+            return;
+        }
+
+        if (agentCache.has(agentId)) {
+            agentSummary = agentCache.get(agentId);
+            return;
+        }
+
+        try {
+            const response = await fetch(`/v1/api/agents/${agentId}`);
+            if (!response.ok) {
+                if (response.status === 404) {
                     agentSummary = null;
                     return;
                 }
-
-                if (agentCache.has(agentId)) {
-                    agentSummary = agentCache.get(agentId);
-                    return;
-                }
-
-                try {
-                    const response = await fetch(`/v1/api/agents/${agentId}`);
-                    if (!response.ok) {
-                        if (response.status === 404) {
-                            agentSummary = null;
-                            return;
-                        }
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
-
-                    const data = await response.json();
-                    agentCache.set(agentId, data);
-                    agentSummary = data;
-                } catch (error) {
-                    console.error('Error loading agent summary:', error);
-                    agentSummary = null;
-                }
+                throw new Error(`HTTP error! status: ${response.status}`);
             }
 
-            async function loadRegressionSummary(regressionId) {
-                if (!regressionId) {
+            const data = await response.json();
+            agentCache.set(agentId, data);
+            agentSummary = data;
+        } catch (error) {
+            console.error('Error loading agent summary:', error);
+            agentSummary = null;
+        }
+    }
+
+    async function loadRegressionSummary(regressionId) {
+        if (!regressionId) {
+            regressionSummary = null;
+            return;
+        }
+
+        if (regressionCache.has(regressionId)) {
+            regressionSummary = regressionCache.get(regressionId);
+            return;
+        }
+
+        try {
+            const response = await fetch(`/v1/api/regression-tests/${regressionId}`);
+            if (!response.ok) {
+                if (response.status === 404) {
                     regressionSummary = null;
                     return;
                 }
-
-                if (regressionCache.has(regressionId)) {
-                    regressionSummary = regressionCache.get(regressionId);
-                    return;
-                }
-
-                try {
-                    const response = await fetch(`/v1/api/regression-tests/${regressionId}`);
-                    if (!response.ok) {
-                        if (response.status === 404) {
-                            regressionSummary = null;
-                            return;
-                        }
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
-
-                    const data = await response.json();
-                    regressionCache.set(regressionId, data);
-                    regressionSummary = data;
-                } catch (error) {
-                    console.error('Error loading regression summary:', error);
-                    regressionSummary = null;
-                }
+                throw new Error(`HTTP error! status: ${response.status}`);
             }
 
-            function setupModelSettingsCollapse(log) {
-                const modelSettingsCollapse = document.getElementById('modelSettingsCollapse');
-                const modelSettingsChevron = document.getElementById('modelSettingsChevron');
+            const data = await response.json();
+            regressionCache.set(regressionId, data);
+            regressionSummary = data;
+        } catch (error) {
+            console.error('Error loading regression summary:', error);
+            regressionSummary = null;
+        }
+    }
 
-                if (!modelSettingsCollapse || !modelSettingsChevron) return;
+    function setupModelSettingsCollapse(log) {
+        const modelSettingsCollapse = document.getElementById('modelSettingsCollapse');
+        const modelSettingsChevron = document.getElementById('modelSettingsChevron');
 
-                // Handle chevron icon rotation
-                modelSettingsCollapse.addEventListener('show.bs.collapse', function () {
-                    modelSettingsChevron.classList.remove('fa-chevron-right');
-                    modelSettingsChevron.classList.add('fa-chevron-down');
-                });
+        if (!modelSettingsCollapse || !modelSettingsChevron) return;
 
-                modelSettingsCollapse.addEventListener('hide.bs.collapse', function () {
-                    modelSettingsChevron.classList.remove('fa-chevron-down');
-                    modelSettingsChevron.classList.add('fa-chevron-right');
-                });
+        // Handle chevron icon rotation
+        modelSettingsCollapse.addEventListener('show.bs.collapse', function () {
+            modelSettingsChevron.classList.remove('fa-chevron-right');
+            modelSettingsChevron.classList.add('fa-chevron-down');
+        });
 
-                // Auto-expand if there are model settings
-                if (log.model_settings !== null && log.model_settings !== undefined) {
-                    const bsCollapse = new bootstrap.Collapse(modelSettingsCollapse, { show: true });
-                }
+        modelSettingsCollapse.addEventListener('hide.bs.collapse', function () {
+            modelSettingsChevron.classList.remove('fa-chevron-down');
+            modelSettingsChevron.classList.add('fa-chevron-right');
+        });
+
+        // Auto-expand if there are model settings
+        if (log.model_settings !== null && log.model_settings !== undefined) {
+            const bsCollapse = new bootstrap.Collapse(modelSettingsCollapse, { show: true });
+        }
+    }
+
+    // Helper functions
+    function findTestCaseById(testCaseId) {
+        return testCasesData.find(tc => tc.id === testCaseId);
+    }
+
+    function formatAgentSummary(agentId) {
+        if (!agentId) {
+            return '<span class="text-muted">Unknown agent</span>';
+        }
+
+        const summary = agentCache.get(agentId) || agentSummary;
+        if (!summary) {
+            return `<span class="badge bg-secondary">${escapeHtml(agentId)}</span>`;
+        }
+
+        const agentName = summary.name ? escapeHtml(summary.name) : 'Unnamed agent';
+        return `<a href="/agents/${escapeHtml(agentId)}" class="badge bg-primary text-decoration-none" target="_blank">${agentName}</a>`;
+    }
+
+    function formatRegressionTimestamp(createdAt) {
+        if (!createdAt) {
+            return 'Unknown';
+        }
+        const date = new Date(createdAt);
+        if (Number.isNaN(date.getTime())) {
+            return 'Unknown';
+        }
+
+        const pad = (value) => String(value).padStart(2, '0');
+        const yyyy = date.getFullYear();
+        const MM = pad(date.getMonth() + 1);
+        const dd = pad(date.getDate());
+        const hh = pad(date.getHours());
+        const mm = pad(date.getMinutes());
+        const ss = pad(date.getSeconds());
+
+        return `${yyyy}${MM}${dd}${hh}${mm}${ss}`;
+    }
+
+    function formatRegressionSummary(regressionId) {
+        if (!regressionId) {
+            return '<span class="text-muted">Ad-hoc execution</span>';
+        }
+
+        const summary = regressionCache.get(regressionId) || regressionSummary;
+        const encodedRegressionId = encodeURIComponent(regressionId);
+
+        if (!summary) {
+            return `<a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">${escapeHtml(regressionId)}</a>`;
+        }
+
+        const timestamp = formatRegressionTimestamp(summary.created_at);
+        const display = timestamp || regressionId;
+        return `<a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">${escapeHtml(display)}</a>`;
+    }
+
+    function formatResponseTime(value) {
+        if (value === null || value === undefined) {
+            return '—';
+        }
+        return `${value}ms`;
+    }
+
+    function hideLoading() {
+        document.getElementById('loadingSpinner').style.display = 'none';
+    }
+
+    function showError(message) {
+        document.getElementById('errorText').textContent = message;
+        document.getElementById('errorMessage').classList.remove('d-none');
+    }
+
+    function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    function formatDate(dateString) {
+        const date = new Date(dateString);
+        return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+    }
+
+    function truncateText(text, maxLength) {
+        if (!text) return '';
+        if (text.length <= maxLength) return escapeHtml(text);
+        return escapeHtml(text.substring(0, maxLength)) + '...';
+    }
+
+    async function copyToClipboard(elementId, buttonElement) {
+        try {
+            const element = document.getElementById(elementId);
+            if (!element) {
+                console.error('Element not found:', elementId);
+                return;
             }
 
-            // Helper functions
-            function findTestCaseById(testCaseId) {
-                return testCasesData.find(tc => tc.id === testCaseId);
+            // Get the text content (without HTML tags)
+            const textToCopy = element.textContent || element.innerText;
+
+            // Use the modern clipboard API
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(textToCopy);
+            } else {
+                // Fallback for older browsers
+                const textArea = document.createElement('textarea');
+                textArea.value = textToCopy;
+                textArea.style.position = 'fixed';
+                textArea.style.left = '-999999px';
+                textArea.style.top = '-999999px';
+                document.body.appendChild(textArea);
+                textArea.focus();
+                textArea.select();
+                document.execCommand('copy');
+                textArea.remove();
             }
 
-            function formatAgentSummary(agentId) {
-                if (!agentId) {
-                    return '<span class="text-muted">Unknown agent</span>';
-                }
+            // Visual feedback
+            const originalIcon = buttonElement.innerHTML;
+            buttonElement.innerHTML = '<i class="fas fa-check text-success"></i>';
+            buttonElement.disabled = true;
 
-                const summary = agentCache.get(agentId) || agentSummary;
-                if (!summary) {
-                    return `<span class="badge bg-secondary">${escapeHtml(agentId)}</span>`;
-                }
+            setTimeout(() => {
+                buttonElement.innerHTML = originalIcon;
+                buttonElement.disabled = false;
+            }, 1500);
 
-                const encodedAgentId = encodeURIComponent(agentId);
-                const agentName = summary.name ? escapeHtml(summary.name) : 'Unnamed agent';
-                const description = summary.description ? `<div class="text-muted small mt-1">${escapeHtml(summary.description)}</div>` : '';
+        } catch (err) {
+            console.error('Failed to copy text: ', err);
 
-                return `
-                    <div class="d-flex flex-column">
-                        <div>
-                            <span class="badge bg-primary">${agentName}</span>
-                            <small class="text-muted ms-2">${escapeHtml(agentId)}</small>
-                        </div>
-                        ${description}
-                        <div class="mt-2 small">
-                            <a href="/test-cases?agentId=${encodedAgentId}" class="text-decoration-none" target="_blank">
-                                View test cases for this agent
-                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                            </a>
-                            <span class="text-muted mx-1">•</span>
-                            <a href="/agents" class="text-decoration-none" target="_blank">
-                                Manage agents
-                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                            </a>
-                        </div>
-                    </div>
-                `;
-            }
+            // Show error feedback
+            const originalIcon = buttonElement.innerHTML;
+            buttonElement.innerHTML = '<i class="fas fa-times text-danger"></i>';
 
-            function formatRegressionSummary(regressionId) {
-                if (!regressionId) {
-                    return '<span class="text-muted">Ad-hoc execution</span>';
-                }
+            setTimeout(() => {
+                buttonElement.innerHTML = originalIcon;
+            }, 1500);
+        }
+    }
 
-                const summary = regressionCache.get(regressionId) || regressionSummary;
-                const encodedRegressionId = encodeURIComponent(regressionId);
+    function reExecuteTest() {
+        if (currentLog) {
+            window.location.href = `/test-execution?logId=${currentLog.id}`;
+        }
+    }
 
-                if (!summary) {
-                    return `<a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">${escapeHtml(regressionId)}<i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i></a>`;
-                }
+    async function deleteLog() {
+        if (!confirm('Are you sure you want to delete this test log? This action cannot be undone.')) {
+            return;
+        }
 
-                const labelParts = [];
-                if (summary.agent && summary.agent.name) {
-                    labelParts.push(summary.agent.name);
-                }
-                if (summary.status) {
-                    labelParts.push(summary.status);
-                }
+        try {
+            const response = await fetch(`/v1/api/test-logs/${logId}`, {
+                method: 'DELETE'
+            });
 
-                const label = labelParts.length > 0 ? labelParts.join(' · ') : regressionId;
-                const successCount = summary.success_count ?? 0;
-                const failedCount = summary.failed_count ?? 0;
-                const totalCount = summary.total_count ?? successCount + failedCount;
-                const counts = `${successCount} passed · ${failedCount} failed (total ${totalCount})`;
-                const timing = summary.completed_at
-                    ? `Completed ${escapeHtml(formatDate(summary.completed_at))}`
-                    : summary.started_at
-                        ? `Started ${escapeHtml(formatDate(summary.started_at))}`
-                        : '';
-                const errorInfo = summary.error_message
-                    ? `<div class="text-danger small mt-1">${escapeHtml(summary.error_message)}</div>`
-                    : '';
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
 
-                return `
-                    <div class="d-flex flex-column">
-                        <div>
-                            <a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">
-                                ${escapeHtml(label)}
-                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                            </a>
-                        </div>
-                        <div class="text-muted small">${escapeHtml(counts)}</div>
-                        ${timing ? `<div class="text-muted small">${timing}</div>` : ''}
-                        ${errorInfo}
-                    </div>
-                `;
-            }
+            alert('Test log deleted successfully!');
+            window.location.href = '/test-logs';
 
-            function formatResponseTime(value) {
-                if (value === null || value === undefined) {
-                    return '—';
-                }
-                return `${value}ms`;
-            }
-
-            function hideLoading() {
-                document.getElementById('loadingSpinner').style.display = 'none';
-            }
-
-            function showError(message) {
-                document.getElementById('errorText').textContent = message;
-                document.getElementById('errorMessage').classList.remove('d-none');
-            }
-
-            function escapeHtml(text) {
-                if (!text) return '';
-                const div = document.createElement('div');
-                div.textContent = text;
-                return div.innerHTML;
-            }
-
-            function formatDate(dateString) {
-                const date = new Date(dateString);
-                return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
-            }
-
-            function truncateText(text, maxLength) {
-                if (!text) return '';
-                if (text.length <= maxLength) return escapeHtml(text);
-                return escapeHtml(text.substring(0, maxLength)) + '...';
-            }
-
-            async function copyToClipboard(elementId, buttonElement) {
-                try {
-                    const element = document.getElementById(elementId);
-                    if (!element) {
-                        console.error('Element not found:', elementId);
-                        return;
-                    }
-
-                    // Get the text content (without HTML tags)
-                    const textToCopy = element.textContent || element.innerText;
-
-                    // Use the modern clipboard API
-                    if (navigator.clipboard && window.isSecureContext) {
-                        await navigator.clipboard.writeText(textToCopy);
-                    } else {
-                        // Fallback for older browsers
-                        const textArea = document.createElement('textarea');
-                        textArea.value = textToCopy;
-                        textArea.style.position = 'fixed';
-                        textArea.style.left = '-999999px';
-                        textArea.style.top = '-999999px';
-                        document.body.appendChild(textArea);
-                        textArea.focus();
-                        textArea.select();
-                        document.execCommand('copy');
-                        textArea.remove();
-                    }
-
-                    // Visual feedback
-                    const originalIcon = buttonElement.innerHTML;
-                    buttonElement.innerHTML = '<i class="fas fa-check text-success"></i>';
-                    buttonElement.disabled = true;
-
-                    setTimeout(() => {
-                        buttonElement.innerHTML = originalIcon;
-                        buttonElement.disabled = false;
-                    }, 1500);
-
-                } catch (err) {
-                    console.error('Failed to copy text: ', err);
-
-                    // Show error feedback
-                    const originalIcon = buttonElement.innerHTML;
-                    buttonElement.innerHTML = '<i class="fas fa-times text-danger"></i>';
-
-                    setTimeout(() => {
-                        buttonElement.innerHTML = originalIcon;
-                    }, 1500);
-                }
-            }
-
-            function reExecuteTest() {
-                if (currentLog) {
-                    window.location.href = `/test-execution?logId=${currentLog.id}`;
-                }
-            }
-
-            async function deleteLog() {
-                if (!confirm('Are you sure you want to delete this test log? This action cannot be undone.')) {
-                    return;
-                }
-
-                try {
-                    const response = await fetch(`/v1/api/test-logs/${logId}`, {
-                        method: 'DELETE'
-                    });
-
-                    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-
-                    alert('Test log deleted successfully!');
-                    window.location.href = '/test-logs';
-
-                } catch (error) {
-                    console.error('Error deleting test log:', error);
-                    alert('Error deleting test log: ' + error.message);
-                }
-            }
-        </script>
+        } catch (error) {
+            console.error('Error deleting test log:', error);
+            alert('Error deleting test log: ' + error.message);
+        }
+    }
+</script>
 {% endblock %}

--- a/templates/test_log_detail.html
+++ b/templates/test_log_detail.html
@@ -50,6 +50,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -307,7 +325,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="/agents">Agents</a>

--- a/templates/test_log_detail.html
+++ b/templates/test_log_detail.html
@@ -1,345 +1,243 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Test Log Details - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
-        }
+{% block page_title %}Test Log Details - LLM Replay System{% endblock %}
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
+{% block extra_css %}
+<style>
+    /* Page Header */
+    .page-header {
+        margin-bottom: 2rem;
+    }
 
-        /* Navigation Styles */
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
 
-        .navbar-brand i {
-            color: var(--primary-color);
+    /* Action buttons in header */
+    .page-header #actionButtons {
+        margin-top: 0.5rem;
+    }
+
+    /* Card Styles */
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
+
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    .card-header {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 1rem 1.5rem;
+        border-radius: 0.75rem 0.75rem 0 0 !important;
+    }
+
+    .card-body {
+        padding: 1.5rem;
+    }
+
+    /* Button Styles */
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
+
+    .btn-outline-secondary {
+        color: var(--text-secondary);
+        border-color: var(--border-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
+
+    .btn-outline-secondary:hover {
+        background-color: var(--text-secondary);
+        border-color: var(--text-secondary);
+        transform: translateY(-1px);
+    }
+
+    .btn-success {
+        background-color: var(--success-color);
+        border-color: var(--success-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    .btn-outline-danger {
+        color: var(--danger-color);
+        border-color: var(--danger-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
+
+    /* Back Button */
+    .back-button {
+        margin-bottom: 1.5rem;
+    }
+
+    /* Status Styles */
+    .status-success {
+        color: var(--success-color);
+        font-weight: 600;
+    }
+
+    .status-failed {
+        color: var(--danger-color);
+        font-weight: 600;
+    }
+
+    /* Table Styles */
+    .info-table {
+        margin-bottom: 0;
+    }
+
+    .info-table td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+
+    .info-table td:first-child {
+        font-weight: 600;
+        color: var(--text-secondary);
+        width: 150px;
+        background-color: #f8fafc;
+    }
+
+    .info-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    /* Code Block Styles */
+    .code-block {
+        background-color: #f1f5f9;
+        border: 1px solid var(--border-color);
+        border-radius: 0.5rem;
+        padding: 1rem;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        max-height: 400px;
+        overflow-y: auto;
+        color: var(--text-primary);
+        white-space: pre-wrap;
+        word-wrap: break-word;
+    }
+
+    /* Loading State */
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
+
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
+
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    /* Error Message */
+    .error-message {
+        background-color: #fef2f2;
+        border: 1px solid #fecaca;
+        color: var(--danger-color);
+        padding: 1rem;
+        border-radius: 0.5rem;
+        margin: 1rem 0;
+    }
+
+    /* Accordion Styles */
+    .accordion-item {
+        border: 1px solid var(--border-color);
+        border-radius: 0.5rem !important;
+        margin-bottom: 0.5rem;
+    }
+
+    .accordion-button {
+        background-color: var(--card-background);
+        color: var(--text-primary);
+        font-weight: 500;
+        border-radius: 0.5rem !important;
+    }
+
+    .accordion-button:not(.collapsed) {
+        background-color: #f8fafc;
+        color: var(--primary-color);
+        box-shadow: none;
+    }
+
+    .accordion-button:focus {
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+
+    .accordion-body {
+        padding: 1rem;
+    }
+
+    /* Alert Styles */
+    .alert-danger {
+        background-color: #fef2f2;
+        border-color: #fecaca;
+        color: var(--danger-color);
+        border-radius: 0.5rem;
+    }
+
+    /* Responsive Improvements */
+    @media (max-width: 768px) {
+        .page-title {
             font-size: 1.5rem;
         }
 
-        .brand-text {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
-
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
-
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
-
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
-
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
-
-        /* Page Header */
-        .page-header {
-            margin-bottom: 2rem;
-        }
-
-        .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
-
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
-
-        /* Action buttons in header */
-        .page-header #actionButtons {
-            margin-top: 0.5rem;
-        }
-
-        /* Card Styles */
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
-
-        .card:hover {
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        }
-
-        .card-header {
-            background-color: #f8fafc;
-            border-bottom: 1px solid var(--border-color);
-            font-weight: 600;
-            color: var(--text-primary);
-            padding: 1rem 1.5rem;
-            border-radius: 0.75rem 0.75rem 0 0 !important;
-        }
-
         .card-body {
-            padding: 1.5rem;
-        }
-
-        /* Button Styles */
-        .btn-primary {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            padding: 0.625rem 1.25rem;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-primary:hover {
-            background-color: var(--primary-hover);
-            border-color: var(--primary-hover);
-            transform: translateY(-1px);
-        }
-
-        .btn-outline-secondary {
-            color: var(--text-secondary);
-            border-color: var(--border-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
-
-        .btn-outline-secondary:hover {
-            background-color: var(--text-secondary);
-            border-color: var(--text-secondary);
-            transform: translateY(-1px);
-        }
-
-        .btn-success {
-            background-color: var(--success-color);
-            border-color: var(--success-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
-
-        .btn-outline-danger {
-            color: var(--danger-color);
-            border-color: var(--danger-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
-
-        /* Back Button */
-        .back-button {
-            margin-bottom: 1.5rem;
-        }
-
-        /* Status Styles */
-        .status-success {
-            color: var(--success-color);
-            font-weight: 600;
-        }
-
-        .status-failed {
-            color: var(--danger-color);
-            font-weight: 600;
-        }
-
-        /* Table Styles */
-        .info-table {
-            margin-bottom: 0;
-        }
-
-        .info-table td {
-            padding: 0.75rem 1rem;
-            border-bottom: 1px solid #f1f5f9;
-            vertical-align: middle;
+            padding: 1rem;
         }
 
         .info-table td:first-child {
-            font-weight: 600;
-            color: var(--text-secondary);
-            width: 150px;
-            background-color: #f8fafc;
-        }
-
-        .info-table tr:last-child td {
-            border-bottom: none;
-        }
-
-        /* Code Block Styles */
-        .code-block {
-            background-color: #f1f5f9;
-            border: 1px solid var(--border-color);
-            border-radius: 0.5rem;
-            padding: 1rem;
-            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+            width: 120px;
             font-size: 0.875rem;
-            line-height: 1.5;
-            max-height: 400px;
-            overflow-y: auto;
-            color: var(--text-primary);
-            white-space: pre-wrap;
-            word-wrap: break-word;
         }
 
-        /* Loading State */
-        .loading-state {
-            text-align: center;
-            padding: 3rem 2rem;
+        .btn-group {
+            flex-direction: column;
+            gap: 0.5rem;
         }
+    }
+</style>
+{% endblock %}
 
-        .loading-spinner {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            color: var(--primary-color);
-        }
-
-        .loading-spinner .spinner-border {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        /* Error Message */
-        .error-message {
-            background-color: #fef2f2;
-            border: 1px solid #fecaca;
-            color: var(--danger-color);
-            padding: 1rem;
-            border-radius: 0.5rem;
-            margin: 1rem 0;
-        }
-
-        /* Accordion Styles */
-        .accordion-item {
-            border: 1px solid var(--border-color);
-            border-radius: 0.5rem !important;
-            margin-bottom: 0.5rem;
-        }
-
-        .accordion-button {
-            background-color: var(--card-background);
-            color: var(--text-primary);
-            font-weight: 500;
-            border-radius: 0.5rem !important;
-        }
-
-        .accordion-button:not(.collapsed) {
-            background-color: #f8fafc;
-            color: var(--primary-color);
-            box-shadow: none;
-        }
-
-        .accordion-button:focus {
-            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-        }
-
-        .accordion-body {
-            padding: 1rem;
-        }
-
-        /* Alert Styles */
-        .alert-danger {
-            background-color: #fef2f2;
-            border-color: #fecaca;
-            color: var(--danger-color);
-            border-radius: 0.5rem;
-        }
-
-        /* Responsive Improvements */
-        @media (max-width: 768px) {
-            .page-title {
-                font-size: 1.5rem;
-            }
-
-            .card-body {
-                padding: 1rem;
-            }
-
-            .info-table td:first-child {
-                width: 120px;
-                font-size: 0.875rem;
-            }
-
-            .btn-group {
-                flex-direction: column;
-                gap: 0.5rem;
-            }
-        }
-    </style>
-</head>
-
-<body>
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/agents">Agents</a>
-                <a class="nav-link" href="/test-cases">Test Cases</a>
-                <a class="nav-link" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link active" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <!-- Header with Action Buttons -->
         <div class="page-header d-flex justify-content-between align-items-start">
@@ -382,566 +280,565 @@
             <!-- Content will be loaded here -->
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script>
-        // Get log ID from URL
-        const logId = '{{ log_id }}';
-        let currentLog = null;
-        let testCasesData = [];
-        let agentSummary = null;
-        let regressionSummary = null;
-        const agentCache = new Map();
-        const regressionCache = new Map();
+            // Get log ID from URL
+            const logId = '{{ log_id }}';
+            let currentLog = null;
+            let testCasesData = [];
+            let agentSummary = null;
+            let regressionSummary = null;
+            const agentCache = new Map();
+            const regressionCache = new Map();
 
-        // Initialize page
-        document.addEventListener('DOMContentLoaded', async function () {
-            await loadTestCases();
-            await loadLogDetails();
-        });
+            // Initialize page
+            document.addEventListener('DOMContentLoaded', async function () {
+                await loadTestCases();
+                await loadLogDetails();
+            });
 
-        async function loadTestCases() {
-            try {
-                const response = await fetch('/v1/api/test-cases/');
-                if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-                testCasesData = await response.json();
-            } catch (error) {
-                console.error('Error loading test cases:', error);
+            async function loadTestCases() {
+                try {
+                    const response = await fetch('/v1/api/test-cases/');
+                    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                    testCasesData = await response.json();
+                } catch (error) {
+                    console.error('Error loading test cases:', error);
+                }
             }
-        }
 
-        async function loadLogDetails() {
-            try {
-                const response = await fetch(`/v1/api/test-logs/${logId}`);
-                if (!response.ok) {
-                    if (response.status === 404) {
-                        throw new Error('Test log not found');
+            async function loadLogDetails() {
+                try {
+                    const response = await fetch(`/v1/api/test-logs/${logId}`);
+                    if (!response.ok) {
+                        if (response.status === 404) {
+                            throw new Error('Test log not found');
+                        }
+                        throw new Error(`HTTP error! status: ${response.status}`);
                     }
-                    throw new Error(`HTTP error! status: ${response.status}`);
+
+                    currentLog = await response.json();
+
+                    await loadAgentSummary(currentLog.agent_id);
+                    if (currentLog.regression_test_id) {
+                        await loadRegressionSummary(currentLog.regression_test_id);
+                    } else {
+                        regressionSummary = null;
+                    }
+
+                    displayLogDetails(currentLog);
+
+                } catch (error) {
+                    console.error('Error loading log details:', error);
+                    showError(error.message);
+                } finally {
+                    hideLoading();
                 }
-
-                currentLog = await response.json();
-
-                await loadAgentSummary(currentLog.agent_id);
-                if (currentLog.regression_test_id) {
-                    await loadRegressionSummary(currentLog.regression_test_id);
-                } else {
-                    regressionSummary = null;
-                }
-
-                displayLogDetails(currentLog);
-
-            } catch (error) {
-                console.error('Error loading log details:', error);
-                showError(error.message);
-            } finally {
-                hideLoading();
             }
-        }
 
-        function displayLogDetails(log) {
-            const testCase = findTestCaseById(log.test_case_id);
-            const responseTime = formatResponseTime(log.response_time_ms);
+            function displayLogDetails(log) {
+                const testCase = findTestCaseById(log.test_case_id);
+                const responseTime = formatResponseTime(log.response_time_ms);
 
-            const detailsHtml = `
-                <div class="row">
-                    <!-- Left Column -->
-                    <div class="col-md-6">
-                        <!-- Execution Information -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <i class="fas fa-info-circle me-2"></i>Execution Information
-                            </div>
-                            <div class="card-body p-0">
-                                <table class="table info-table mb-0">
-                                    <tr>
-                                        <td>Log ID:</td>
-                                        <td><code>${escapeHtml(log.id)}</code></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Status:</td>
-                                        <td>
-                                            <span class="status-${log.status}">
-                                                <i class="fas fa-${log.status === 'success' ? 'check-circle' : 'times-circle'} me-1"></i>
-                                                ${log.status.toUpperCase()}
-                                            </span>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Model:</td>
-                                        <td>${escapeHtml(log.model_name)}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Agent:</td>
-                                        <td>${formatAgentSummary(log.agent_id)}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Regression Test:</td>
-                                        <td>${formatRegressionSummary(log.regression_test_id)}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Response Time:</td>
-                                        <td><strong>${responseTime}</strong></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Test Case:</td>
-                                        <td>
-                                            <div>
-                                                <a href="/test-cases/${log.test_case_id}" class="text-decoration-none" target="_blank">
-                                                    ${escapeHtml(testCase?.name || log.test_case_id)}
-                                                    <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                                                </a>
-                                            </div>
-                                            ${testCase?.description ? `
-                                                <div class="text-muted mt-1" style="font-size: 0.9em;">
-                                                    <span title="${escapeHtml(testCase.description)}" style="cursor: help;">
-                                                        ${truncateText(testCase.description, 100)}
-                                                    </span>
+                const detailsHtml = `
+                    <div class="row">
+                        <!-- Left Column -->
+                        <div class="col-md-6">
+                            <!-- Execution Information -->
+                            <div class="card mb-4">
+                                <div class="card-header">
+                                    <i class="fas fa-info-circle me-2"></i>Execution Information
+                                </div>
+                                <div class="card-body p-0">
+                                    <table class="table info-table mb-0">
+                                        <tr>
+                                            <td>Log ID:</td>
+                                            <td><code>${escapeHtml(log.id)}</code></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Status:</td>
+                                            <td>
+                                                <span class="status-${log.status}">
+                                                    <i class="fas fa-${log.status === 'success' ? 'check-circle' : 'times-circle'} me-1"></i>
+                                                    ${log.status.toUpperCase()}
+                                                </span>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Model:</td>
+                                            <td>${escapeHtml(log.model_name)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Agent:</td>
+                                            <td>${formatAgentSummary(log.agent_id)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Regression Test:</td>
+                                            <td>${formatRegressionSummary(log.regression_test_id)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Response Time:</td>
+                                            <td><strong>${responseTime}</strong></td>
+                                        </tr>
+                                        <tr>
+                                            <td>Test Case:</td>
+                                            <td>
+                                                <div>
+                                                    <a href="/test-cases/${log.test_case_id}" class="text-decoration-none" target="_blank">
+                                                        ${escapeHtml(testCase?.name || log.test_case_id)}
+                                                        <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                                                    </a>
                                                 </div>
-                                            ` : ''}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Executed At:</td>
-                                        <td>${escapeHtml(formatDate(log.created_at))}</td>
-                                    </tr>
-                                </table>
+                                                ${testCase?.description ? `
+                                                    <div class="text-muted mt-1" style="font-size: 0.9em;">
+                                                        <span title="${escapeHtml(testCase.description)}" style="cursor: help;">
+                                                            ${truncateText(testCase.description, 100)}
+                                                        </span>
+                                                    </div>
+                                                ` : ''}
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Executed At:</td>
+                                            <td>${escapeHtml(formatDate(log.created_at))}</td>
+                                        </tr>
+                                    </table>
+                                </div>
                             </div>
-                        </div>
 
 
 
-                        <!-- System Prompt -->
-                        <div class="card mb-4">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <span>
-                                    <i class="fas fa-terminal me-2"></i>System Prompt
-                                </span>
-                                <button class="btn btn-sm btn-outline-secondary" onclick="copyToClipboard('systemPromptContent', this)" title="Copy System Prompt">
-                                    <i class="fas fa-copy"></i>
-                                </button>
-                            </div>
-                            <div class="card-body">
-                                <div class="code-block" id="systemPromptContent">${escapeHtml(log.system_prompt)}</div>
-                            </div>
-                        </div>
-
-                        <!-- User Message -->
-                        <div class="card mb-4">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <span>
-                                    <i class="fas fa-comment me-2"></i>User Message
-                                </span>
-                                <button class="btn btn-sm btn-outline-secondary" onclick="copyToClipboard('userMessageContent', this)" title="Copy User Message">
-                                    <i class="fas fa-copy"></i>
-                                </button>
-                            </div>
-                            <div class="card-body">
-                                <div class="code-block" id="userMessageContent">${escapeHtml(log.user_message)}</div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Right Column -->
-                    <div class="col-md-6">
-                        <!-- LLM Response -->
-                        ${log.llm_response ? `
+                            <!-- System Prompt -->
                             <div class="card mb-4">
-                                <div class="card-header">
-                                    <i class="fas fa-robot me-2"></i>LLM Response
-                                </div>
-                                <div class="card-body">
-                                    <div class="code-block">${escapeHtml(log.llm_response)}</div>
-                                </div>
-                            </div>
-                        ` : `
-                            <div class="card mb-4">
-                                <div class="card-header">
-                                    <i class="fas fa-robot me-2"></i>LLM Response
-                                </div>
-                                <div class="card-body">
-                                    <p class="text-muted mb-0">No LLM response available</p>
-                                </div>
-                            </div>
-                        `}
-
-                        <!-- Model Settings -->
-                        <div class="card mb-4">
-                            <div class="card-header">
-                                <div class="d-flex align-items-center">
-                                    <button class="btn btn-link text-decoration-none p-0 text-muted" type="button"
-                                        data-bs-toggle="collapse" data-bs-target="#modelSettingsCollapse"
-                                        aria-expanded="false" aria-controls="modelSettingsCollapse">
-                                        <i class="fas fa-chevron-right me-1" id="modelSettingsChevron"
-                                            style="font-size: 0.8em;"></i>
-                                        <span style="font-size: 0.9em;">Model Settings</span>
+                                <div class="card-header d-flex justify-content-between align-items-center">
+                                    <span>
+                                        <i class="fas fa-terminal me-2"></i>System Prompt
+                                    </span>
+                                    <button class="btn btn-sm btn-outline-secondary" onclick="copyToClipboard('systemPromptContent', this)" title="Copy System Prompt">
+                                        <i class="fas fa-copy"></i>
                                     </button>
                                 </div>
-                            </div>
-                            <div class="collapse" id="modelSettingsCollapse">
                                 <div class="card-body">
-                                    ${log.model_settings !== null && log.model_settings !== undefined ?
-                    `<pre class="bg-light p-3 rounded mb-0"><code>${escapeHtml(JSON.stringify(log.model_settings, null, 2))}</code></pre>` :
-                    '<p class="text-muted mb-0">No model settings specified</p>'
-                }
+                                    <div class="code-block" id="systemPromptContent">${escapeHtml(log.system_prompt)}</div>
+                                </div>
+                            </div>
+
+                            <!-- User Message -->
+                            <div class="card mb-4">
+                                <div class="card-header d-flex justify-content-between align-items-center">
+                                    <span>
+                                        <i class="fas fa-comment me-2"></i>User Message
+                                    </span>
+                                    <button class="btn btn-sm btn-outline-secondary" onclick="copyToClipboard('userMessageContent', this)" title="Copy User Message">
+                                        <i class="fas fa-copy"></i>
+                                    </button>
+                                </div>
+                                <div class="card-body">
+                                    <div class="code-block" id="userMessageContent">${escapeHtml(log.user_message)}</div>
                                 </div>
                             </div>
                         </div>
 
-                        <!-- Tools Configuration -->
-                        ${log.tools && log.tools.length > 0 ? `
+                        <!-- Right Column -->
+                        <div class="col-md-6">
+                            <!-- LLM Response -->
+                            ${log.llm_response ? `
+                                <div class="card mb-4">
+                                    <div class="card-header">
+                                        <i class="fas fa-robot me-2"></i>LLM Response
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="code-block">${escapeHtml(log.llm_response)}</div>
+                                    </div>
+                                </div>
+                            ` : `
+                                <div class="card mb-4">
+                                    <div class="card-header">
+                                        <i class="fas fa-robot me-2"></i>LLM Response
+                                    </div>
+                                    <div class="card-body">
+                                        <p class="text-muted mb-0">No LLM response available</p>
+                                    </div>
+                                </div>
+                            `}
+
+                            <!-- Model Settings -->
                             <div class="card mb-4">
                                 <div class="card-header">
-                                    <i class="fas fa-wrench me-2"></i>Tools Configuration
+                                    <div class="d-flex align-items-center">
+                                        <button class="btn btn-link text-decoration-none p-0 text-muted" type="button"
+                                            data-bs-toggle="collapse" data-bs-target="#modelSettingsCollapse"
+                                            aria-expanded="false" aria-controls="modelSettingsCollapse">
+                                            <i class="fas fa-chevron-right me-1" id="modelSettingsChevron"
+                                                style="font-size: 0.8em;"></i>
+                                            <span style="font-size: 0.9em;">Model Settings</span>
+                                        </button>
+                                    </div>
                                 </div>
-                                <div class="card-body">
-                                    <div class="accordion" id="logToolsAccordion">
-                                        ${log.tools.map((tool, index) => `
-                                            <div class="accordion-item">
-                                                <h2 class="accordion-header" id="logHeading${index}">
-                                                    <button class="accordion-button collapsed" type="button"
-                                                            data-bs-toggle="collapse" data-bs-target="#logCollapse${index}"
-                                                            aria-expanded="false" aria-controls="logCollapse${index}">
-                                                        <i class="fas fa-wrench me-2"></i>
-                                                        <strong>${escapeHtml(tool.function?.name || 'Unknown Tool')}</strong>
-                                                    </button>
-                                                </h2>
-                                                <div id="logCollapse${index}" class="accordion-collapse collapse"
-                                                     aria-labelledby="logHeading${index}" data-bs-parent="#logToolsAccordion">
-                                                    <div class="accordion-body">
-                                                        <div class="code-block" style="font-size: 0.85em;">${escapeHtml(JSON.stringify(tool, null, 2))}</div>
+                                <div class="collapse" id="modelSettingsCollapse">
+                                    <div class="card-body">
+                                        ${log.model_settings !== null && log.model_settings !== undefined ?
+                        `<pre class="bg-light p-3 rounded mb-0"><code>${escapeHtml(JSON.stringify(log.model_settings, null, 2))}</code></pre>` :
+                        '<p class="text-muted mb-0">No model settings specified</p>'
+                    }
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Tools Configuration -->
+                            ${log.tools && log.tools.length > 0 ? `
+                                <div class="card mb-4">
+                                    <div class="card-header">
+                                        <i class="fas fa-wrench me-2"></i>Tools Configuration
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="accordion" id="logToolsAccordion">
+                                            ${log.tools.map((tool, index) => `
+                                                <div class="accordion-item">
+                                                    <h2 class="accordion-header" id="logHeading${index}">
+                                                        <button class="accordion-button collapsed" type="button"
+                                                                data-bs-toggle="collapse" data-bs-target="#logCollapse${index}"
+                                                                aria-expanded="false" aria-controls="logCollapse${index}">
+                                                            <i class="fas fa-wrench me-2"></i>
+                                                            <strong>${escapeHtml(tool.function?.name || 'Unknown Tool')}</strong>
+                                                        </button>
+                                                    </h2>
+                                                    <div id="logCollapse${index}" class="accordion-collapse collapse"
+                                                         aria-labelledby="logHeading${index}" data-bs-parent="#logToolsAccordion">
+                                                        <div class="accordion-body">
+                                                            <div class="code-block" style="font-size: 0.85em;">${escapeHtml(JSON.stringify(tool, null, 2))}</div>
+                                                        </div>
                                                     </div>
                                                 </div>
-                                            </div>
-                                        `).join('')}
+                                            `).join('')}
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        ` : `
-                            <div class="card mb-4">
-                                <div class="card-header">
-                                    <i class="fas fa-wrench me-2"></i>Tools
+                            ` : `
+                                <div class="card mb-4">
+                                    <div class="card-header">
+                                        <i class="fas fa-wrench me-2"></i>Tools
+                                    </div>
+                                    <div class="card-body">
+                                        <p class="text-muted mb-0">No tools used</p>
+                                    </div>
                                 </div>
-                                <div class="card-body">
-                                    <p class="text-muted mb-0">No tools used</p>
-                                </div>
-                            </div>
-                        `}
+                            `}
+                        </div>
                     </div>
-                </div>
 
-                ${log.error_message ? `
-                    <div class="row">
-                        <div class="col-12 mb-4">
-                            <div class="card">
-                                <div class="card-header text-danger">
-                                    <i class="fas fa-exclamation-triangle me-2"></i>Error Message
-                                </div>
-                                <div class="card-body">
-                                    <div class="alert alert-danger mb-0">
-                                        ${escapeHtml(log.error_message)}
+                    ${log.error_message ? `
+                        <div class="row">
+                            <div class="col-12 mb-4">
+                                <div class="card">
+                                    <div class="card-header text-danger">
+                                        <i class="fas fa-exclamation-triangle me-2"></i>Error Message
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="alert alert-danger mb-0">
+                                            ${escapeHtml(log.error_message)}
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                ` : ''}
-            `;
+                    ` : ''}
+                `;
 
-            document.getElementById('logDetailsContent').innerHTML = detailsHtml;
-            document.getElementById('logDetailsContent').classList.remove('d-none');
-            document.getElementById('actionButtons').classList.remove('d-none');
+                document.getElementById('logDetailsContent').innerHTML = detailsHtml;
+                document.getElementById('logDetailsContent').classList.remove('d-none');
+                document.getElementById('actionButtons').classList.remove('d-none');
 
-            // Setup Model Settings collapse handlers
-            setupModelSettingsCollapse(log);
-        }
-
-        async function loadAgentSummary(agentId) {
-            if (!agentId) {
-                agentSummary = null;
-                return;
+                // Setup Model Settings collapse handlers
+                setupModelSettingsCollapse(log);
             }
 
-            if (agentCache.has(agentId)) {
-                agentSummary = agentCache.get(agentId);
-                return;
-            }
-
-            try {
-                const response = await fetch(`/v1/api/agents/${agentId}`);
-                if (!response.ok) {
-                    if (response.status === 404) {
-                        agentSummary = null;
-                        return;
-                    }
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
-
-                const data = await response.json();
-                agentCache.set(agentId, data);
-                agentSummary = data;
-            } catch (error) {
-                console.error('Error loading agent summary:', error);
-                agentSummary = null;
-            }
-        }
-
-        async function loadRegressionSummary(regressionId) {
-            if (!regressionId) {
-                regressionSummary = null;
-                return;
-            }
-
-            if (regressionCache.has(regressionId)) {
-                regressionSummary = regressionCache.get(regressionId);
-                return;
-            }
-
-            try {
-                const response = await fetch(`/v1/api/regression-tests/${regressionId}`);
-                if (!response.ok) {
-                    if (response.status === 404) {
-                        regressionSummary = null;
-                        return;
-                    }
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
-
-                const data = await response.json();
-                regressionCache.set(regressionId, data);
-                regressionSummary = data;
-            } catch (error) {
-                console.error('Error loading regression summary:', error);
-                regressionSummary = null;
-            }
-        }
-
-        function setupModelSettingsCollapse(log) {
-            const modelSettingsCollapse = document.getElementById('modelSettingsCollapse');
-            const modelSettingsChevron = document.getElementById('modelSettingsChevron');
-
-            if (!modelSettingsCollapse || !modelSettingsChevron) return;
-
-            // Handle chevron icon rotation
-            modelSettingsCollapse.addEventListener('show.bs.collapse', function () {
-                modelSettingsChevron.classList.remove('fa-chevron-right');
-                modelSettingsChevron.classList.add('fa-chevron-down');
-            });
-
-            modelSettingsCollapse.addEventListener('hide.bs.collapse', function () {
-                modelSettingsChevron.classList.remove('fa-chevron-down');
-                modelSettingsChevron.classList.add('fa-chevron-right');
-            });
-
-            // Auto-expand if there are model settings
-            if (log.model_settings !== null && log.model_settings !== undefined) {
-                const bsCollapse = new bootstrap.Collapse(modelSettingsCollapse, { show: true });
-            }
-        }
-
-        // Helper functions
-        function findTestCaseById(testCaseId) {
-            return testCasesData.find(tc => tc.id === testCaseId);
-        }
-
-        function formatAgentSummary(agentId) {
-            if (!agentId) {
-                return '<span class="text-muted">Unknown agent</span>';
-            }
-
-            const summary = agentCache.get(agentId) || agentSummary;
-            if (!summary) {
-                return `<span class="badge bg-secondary">${escapeHtml(agentId)}</span>`;
-            }
-
-            const encodedAgentId = encodeURIComponent(agentId);
-            const agentName = summary.name ? escapeHtml(summary.name) : 'Unnamed agent';
-            const description = summary.description ? `<div class="text-muted small mt-1">${escapeHtml(summary.description)}</div>` : '';
-
-            return `
-                <div class="d-flex flex-column">
-                    <div>
-                        <span class="badge bg-primary">${agentName}</span>
-                        <small class="text-muted ms-2">${escapeHtml(agentId)}</small>
-                    </div>
-                    ${description}
-                    <div class="mt-2 small">
-                        <a href="/test-cases?agentId=${encodedAgentId}" class="text-decoration-none" target="_blank">
-                            View test cases for this agent
-                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                        </a>
-                        <span class="text-muted mx-1">•</span>
-                        <a href="/agents" class="text-decoration-none" target="_blank">
-                            Manage agents
-                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                        </a>
-                    </div>
-                </div>
-            `;
-        }
-
-        function formatRegressionSummary(regressionId) {
-            if (!regressionId) {
-                return '<span class="text-muted">Ad-hoc execution</span>';
-            }
-
-            const summary = regressionCache.get(regressionId) || regressionSummary;
-            const encodedRegressionId = encodeURIComponent(regressionId);
-
-            if (!summary) {
-                return `<a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">${escapeHtml(regressionId)}<i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i></a>`;
-            }
-
-            const labelParts = [];
-            if (summary.agent && summary.agent.name) {
-                labelParts.push(summary.agent.name);
-            }
-            if (summary.status) {
-                labelParts.push(summary.status);
-            }
-
-            const label = labelParts.length > 0 ? labelParts.join(' · ') : regressionId;
-            const successCount = summary.success_count ?? 0;
-            const failedCount = summary.failed_count ?? 0;
-            const totalCount = summary.total_count ?? successCount + failedCount;
-            const counts = `${successCount} passed · ${failedCount} failed (total ${totalCount})`;
-            const timing = summary.completed_at
-                ? `Completed ${escapeHtml(formatDate(summary.completed_at))}`
-                : summary.started_at
-                    ? `Started ${escapeHtml(formatDate(summary.started_at))}`
-                    : '';
-            const errorInfo = summary.error_message
-                ? `<div class="text-danger small mt-1">${escapeHtml(summary.error_message)}</div>`
-                : '';
-
-            return `
-                <div class="d-flex flex-column">
-                    <div>
-                        <a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">
-                            ${escapeHtml(label)}
-                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
-                        </a>
-                    </div>
-                    <div class="text-muted small">${escapeHtml(counts)}</div>
-                    ${timing ? `<div class="text-muted small">${timing}</div>` : ''}
-                    ${errorInfo}
-                </div>
-            `;
-        }
-
-        function formatResponseTime(value) {
-            if (value === null || value === undefined) {
-                return '—';
-            }
-            return `${value}ms`;
-        }
-
-        function hideLoading() {
-            document.getElementById('loadingSpinner').style.display = 'none';
-        }
-
-        function showError(message) {
-            document.getElementById('errorText').textContent = message;
-            document.getElementById('errorMessage').classList.remove('d-none');
-        }
-
-        function escapeHtml(text) {
-            if (!text) return '';
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
-        }
-
-        function formatDate(dateString) {
-            const date = new Date(dateString);
-            return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
-        }
-
-        function truncateText(text, maxLength) {
-            if (!text) return '';
-            if (text.length <= maxLength) return escapeHtml(text);
-            return escapeHtml(text.substring(0, maxLength)) + '...';
-        }
-
-        async function copyToClipboard(elementId, buttonElement) {
-            try {
-                const element = document.getElementById(elementId);
-                if (!element) {
-                    console.error('Element not found:', elementId);
+            async function loadAgentSummary(agentId) {
+                if (!agentId) {
+                    agentSummary = null;
                     return;
                 }
 
-                // Get the text content (without HTML tags)
-                const textToCopy = element.textContent || element.innerText;
-
-                // Use the modern clipboard API
-                if (navigator.clipboard && window.isSecureContext) {
-                    await navigator.clipboard.writeText(textToCopy);
-                } else {
-                    // Fallback for older browsers
-                    const textArea = document.createElement('textarea');
-                    textArea.value = textToCopy;
-                    textArea.style.position = 'fixed';
-                    textArea.style.left = '-999999px';
-                    textArea.style.top = '-999999px';
-                    document.body.appendChild(textArea);
-                    textArea.focus();
-                    textArea.select();
-                    document.execCommand('copy');
-                    textArea.remove();
+                if (agentCache.has(agentId)) {
+                    agentSummary = agentCache.get(agentId);
+                    return;
                 }
 
-                // Visual feedback
-                const originalIcon = buttonElement.innerHTML;
-                buttonElement.innerHTML = '<i class="fas fa-check text-success"></i>';
-                buttonElement.disabled = true;
+                try {
+                    const response = await fetch(`/v1/api/agents/${agentId}`);
+                    if (!response.ok) {
+                        if (response.status === 404) {
+                            agentSummary = null;
+                            return;
+                        }
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
 
-                setTimeout(() => {
-                    buttonElement.innerHTML = originalIcon;
-                    buttonElement.disabled = false;
-                }, 1500);
-
-            } catch (err) {
-                console.error('Failed to copy text: ', err);
-
-                // Show error feedback
-                const originalIcon = buttonElement.innerHTML;
-                buttonElement.innerHTML = '<i class="fas fa-times text-danger"></i>';
-
-                setTimeout(() => {
-                    buttonElement.innerHTML = originalIcon;
-                }, 1500);
-            }
-        }
-
-        function reExecuteTest() {
-            if (currentLog) {
-                const agentParam = currentLog.agent_id ? `&agentId=${encodeURIComponent(currentLog.agent_id)}` : '';
-                window.location.href = `/test-execution?testCaseId=${currentLog.test_case_id}${agentParam}`;
-            }
-        }
-
-        async function deleteLog() {
-            if (!confirm('Are you sure you want to delete this test log? This action cannot be undone.')) {
-                return;
+                    const data = await response.json();
+                    agentCache.set(agentId, data);
+                    agentSummary = data;
+                } catch (error) {
+                    console.error('Error loading agent summary:', error);
+                    agentSummary = null;
+                }
             }
 
-            try {
-                const response = await fetch(`/v1/api/test-logs/${logId}`, {
-                    method: 'DELETE'
+            async function loadRegressionSummary(regressionId) {
+                if (!regressionId) {
+                    regressionSummary = null;
+                    return;
+                }
+
+                if (regressionCache.has(regressionId)) {
+                    regressionSummary = regressionCache.get(regressionId);
+                    return;
+                }
+
+                try {
+                    const response = await fetch(`/v1/api/regression-tests/${regressionId}`);
+                    if (!response.ok) {
+                        if (response.status === 404) {
+                            regressionSummary = null;
+                            return;
+                        }
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+
+                    const data = await response.json();
+                    regressionCache.set(regressionId, data);
+                    regressionSummary = data;
+                } catch (error) {
+                    console.error('Error loading regression summary:', error);
+                    regressionSummary = null;
+                }
+            }
+
+            function setupModelSettingsCollapse(log) {
+                const modelSettingsCollapse = document.getElementById('modelSettingsCollapse');
+                const modelSettingsChevron = document.getElementById('modelSettingsChevron');
+
+                if (!modelSettingsCollapse || !modelSettingsChevron) return;
+
+                // Handle chevron icon rotation
+                modelSettingsCollapse.addEventListener('show.bs.collapse', function () {
+                    modelSettingsChevron.classList.remove('fa-chevron-right');
+                    modelSettingsChevron.classList.add('fa-chevron-down');
                 });
 
-                if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                modelSettingsCollapse.addEventListener('hide.bs.collapse', function () {
+                    modelSettingsChevron.classList.remove('fa-chevron-down');
+                    modelSettingsChevron.classList.add('fa-chevron-right');
+                });
 
-                alert('Test log deleted successfully!');
-                window.location.href = '/test-logs';
-
-            } catch (error) {
-                console.error('Error deleting test log:', error);
-                alert('Error deleting test log: ' + error.message);
+                // Auto-expand if there are model settings
+                if (log.model_settings !== null && log.model_settings !== undefined) {
+                    const bsCollapse = new bootstrap.Collapse(modelSettingsCollapse, { show: true });
+                }
             }
-        }
-    </script>
-</body>
 
-</html>
+            // Helper functions
+            function findTestCaseById(testCaseId) {
+                return testCasesData.find(tc => tc.id === testCaseId);
+            }
+
+            function formatAgentSummary(agentId) {
+                if (!agentId) {
+                    return '<span class="text-muted">Unknown agent</span>';
+                }
+
+                const summary = agentCache.get(agentId) || agentSummary;
+                if (!summary) {
+                    return `<span class="badge bg-secondary">${escapeHtml(agentId)}</span>`;
+                }
+
+                const encodedAgentId = encodeURIComponent(agentId);
+                const agentName = summary.name ? escapeHtml(summary.name) : 'Unnamed agent';
+                const description = summary.description ? `<div class="text-muted small mt-1">${escapeHtml(summary.description)}</div>` : '';
+
+                return `
+                    <div class="d-flex flex-column">
+                        <div>
+                            <span class="badge bg-primary">${agentName}</span>
+                            <small class="text-muted ms-2">${escapeHtml(agentId)}</small>
+                        </div>
+                        ${description}
+                        <div class="mt-2 small">
+                            <a href="/test-cases?agentId=${encodedAgentId}" class="text-decoration-none" target="_blank">
+                                View test cases for this agent
+                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                            </a>
+                            <span class="text-muted mx-1">•</span>
+                            <a href="/agents" class="text-decoration-none" target="_blank">
+                                Manage agents
+                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                            </a>
+                        </div>
+                    </div>
+                `;
+            }
+
+            function formatRegressionSummary(regressionId) {
+                if (!regressionId) {
+                    return '<span class="text-muted">Ad-hoc execution</span>';
+                }
+
+                const summary = regressionCache.get(regressionId) || regressionSummary;
+                const encodedRegressionId = encodeURIComponent(regressionId);
+
+                if (!summary) {
+                    return `<a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">${escapeHtml(regressionId)}<i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i></a>`;
+                }
+
+                const labelParts = [];
+                if (summary.agent && summary.agent.name) {
+                    labelParts.push(summary.agent.name);
+                }
+                if (summary.status) {
+                    labelParts.push(summary.status);
+                }
+
+                const label = labelParts.length > 0 ? labelParts.join(' · ') : regressionId;
+                const successCount = summary.success_count ?? 0;
+                const failedCount = summary.failed_count ?? 0;
+                const totalCount = summary.total_count ?? successCount + failedCount;
+                const counts = `${successCount} passed · ${failedCount} failed (total ${totalCount})`;
+                const timing = summary.completed_at
+                    ? `Completed ${escapeHtml(formatDate(summary.completed_at))}`
+                    : summary.started_at
+                        ? `Started ${escapeHtml(formatDate(summary.started_at))}`
+                        : '';
+                const errorInfo = summary.error_message
+                    ? `<div class="text-danger small mt-1">${escapeHtml(summary.error_message)}</div>`
+                    : '';
+
+                return `
+                    <div class="d-flex flex-column">
+                        <div>
+                            <a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">
+                                ${escapeHtml(label)}
+                                <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                            </a>
+                        </div>
+                        <div class="text-muted small">${escapeHtml(counts)}</div>
+                        ${timing ? `<div class="text-muted small">${timing}</div>` : ''}
+                        ${errorInfo}
+                    </div>
+                `;
+            }
+
+            function formatResponseTime(value) {
+                if (value === null || value === undefined) {
+                    return '—';
+                }
+                return `${value}ms`;
+            }
+
+            function hideLoading() {
+                document.getElementById('loadingSpinner').style.display = 'none';
+            }
+
+            function showError(message) {
+                document.getElementById('errorText').textContent = message;
+                document.getElementById('errorMessage').classList.remove('d-none');
+            }
+
+            function escapeHtml(text) {
+                if (!text) return '';
+                const div = document.createElement('div');
+                div.textContent = text;
+                return div.innerHTML;
+            }
+
+            function formatDate(dateString) {
+                const date = new Date(dateString);
+                return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+            }
+
+            function truncateText(text, maxLength) {
+                if (!text) return '';
+                if (text.length <= maxLength) return escapeHtml(text);
+                return escapeHtml(text.substring(0, maxLength)) + '...';
+            }
+
+            async function copyToClipboard(elementId, buttonElement) {
+                try {
+                    const element = document.getElementById(elementId);
+                    if (!element) {
+                        console.error('Element not found:', elementId);
+                        return;
+                    }
+
+                    // Get the text content (without HTML tags)
+                    const textToCopy = element.textContent || element.innerText;
+
+                    // Use the modern clipboard API
+                    if (navigator.clipboard && window.isSecureContext) {
+                        await navigator.clipboard.writeText(textToCopy);
+                    } else {
+                        // Fallback for older browsers
+                        const textArea = document.createElement('textarea');
+                        textArea.value = textToCopy;
+                        textArea.style.position = 'fixed';
+                        textArea.style.left = '-999999px';
+                        textArea.style.top = '-999999px';
+                        document.body.appendChild(textArea);
+                        textArea.focus();
+                        textArea.select();
+                        document.execCommand('copy');
+                        textArea.remove();
+                    }
+
+                    // Visual feedback
+                    const originalIcon = buttonElement.innerHTML;
+                    buttonElement.innerHTML = '<i class="fas fa-check text-success"></i>';
+                    buttonElement.disabled = true;
+
+                    setTimeout(() => {
+                        buttonElement.innerHTML = originalIcon;
+                        buttonElement.disabled = false;
+                    }, 1500);
+
+                } catch (err) {
+                    console.error('Failed to copy text: ', err);
+
+                    // Show error feedback
+                    const originalIcon = buttonElement.innerHTML;
+                    buttonElement.innerHTML = '<i class="fas fa-times text-danger"></i>';
+
+                    setTimeout(() => {
+                        buttonElement.innerHTML = originalIcon;
+                    }, 1500);
+                }
+            }
+
+            function reExecuteTest() {
+                if (currentLog) {
+                    const agentParam = currentLog.agent_id ? `&agentId=${encodeURIComponent(currentLog.agent_id)}` : '';
+                    window.location.href = `/test-execution?testCaseId=${currentLog.test_case_id}${agentParam}`;
+                }
+            }
+
+            async function deleteLog() {
+                if (!confirm('Are you sure you want to delete this test log? This action cannot be undone.')) {
+                    return;
+                }
+
+                try {
+                    const response = await fetch(`/v1/api/test-logs/${logId}`, {
+                        method: 'DELETE'
+                    });
+
+                    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+
+                    alert('Test log deleted successfully!');
+                    window.location.href = '/test-logs';
+
+                } catch (error) {
+                    console.error('Error deleting test log:', error);
+                    alert('Error deleting test log: ' + error.message);
+                }
+            }
+        </script>
+{% endblock %}

--- a/templates/test_log_detail.html
+++ b/templates/test_log_detail.html
@@ -310,9 +310,11 @@
                 <span>LLM Replay System</span>
             </a>
             <div class="navbar-nav ms-auto">
+                <a class="nav-link" href="/agents">Agents</a>
                 <a class="nav-link" href="/test-cases">Test Cases</a>
+                <a class="nav-link" href="/regression-tests">Regression Tests</a>
                 <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link" href="/test-logs">Test Logs</a>
+                <a class="nav-link active" href="/test-logs">Test Logs</a>
             </div>
         </div>
     </nav>
@@ -366,6 +368,10 @@
         const logId = '{{ log_id }}';
         let currentLog = null;
         let testCasesData = [];
+        let agentSummary = null;
+        let regressionSummary = null;
+        const agentCache = new Map();
+        const regressionCache = new Map();
 
         // Initialize page
         document.addEventListener('DOMContentLoaded', async function () {
@@ -394,6 +400,14 @@
                 }
 
                 currentLog = await response.json();
+
+                await loadAgentSummary(currentLog.agent_id);
+                if (currentLog.regression_test_id) {
+                    await loadRegressionSummary(currentLog.regression_test_id);
+                } else {
+                    regressionSummary = null;
+                }
+
                 displayLogDetails(currentLog);
 
             } catch (error) {
@@ -406,6 +420,7 @@
 
         function displayLogDetails(log) {
             const testCase = findTestCaseById(log.test_case_id);
+            const responseTime = formatResponseTime(log.response_time_ms);
 
             const detailsHtml = `
                 <div class="row">
@@ -436,8 +451,16 @@
                                         <td>${escapeHtml(log.model_name)}</td>
                                     </tr>
                                     <tr>
+                                        <td>Agent:</td>
+                                        <td>${formatAgentSummary(log.agent_id)}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Regression Test:</td>
+                                        <td>${formatRegressionSummary(log.regression_test_id)}</td>
+                                    </tr>
+                                    <tr>
                                         <td>Response Time:</td>
-                                        <td><strong>${log.response_time_ms}ms</strong></td>
+                                        <td><strong>${responseTime}</strong></td>
                                     </tr>
                                     <tr>
                                         <td>Test Case:</td>
@@ -459,7 +482,7 @@
                                     </tr>
                                     <tr>
                                         <td>Executed At:</td>
-                                        <td>${formatDate(log.created_at)}</td>
+                                        <td>${escapeHtml(formatDate(log.created_at))}</td>
                                     </tr>
                                 </table>
                             </div>
@@ -537,7 +560,7 @@
                             <div class="collapse" id="modelSettingsCollapse">
                                 <div class="card-body">
                                     ${log.model_settings !== null && log.model_settings !== undefined ?
-                    `<pre class="bg-light p-3 rounded mb-0"><code>${JSON.stringify(log.model_settings, null, 2)}</code></pre>` :
+                    `<pre class="bg-light p-3 rounded mb-0"><code>${escapeHtml(JSON.stringify(log.model_settings, null, 2))}</code></pre>` :
                     '<p class="text-muted mb-0">No model settings specified</p>'
                 }
                                 </div>
@@ -612,6 +635,66 @@
             setupModelSettingsCollapse(log);
         }
 
+        async function loadAgentSummary(agentId) {
+            if (!agentId) {
+                agentSummary = null;
+                return;
+            }
+
+            if (agentCache.has(agentId)) {
+                agentSummary = agentCache.get(agentId);
+                return;
+            }
+
+            try {
+                const response = await fetch(`/v1/api/agents/${agentId}`);
+                if (!response.ok) {
+                    if (response.status === 404) {
+                        agentSummary = null;
+                        return;
+                    }
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                agentCache.set(agentId, data);
+                agentSummary = data;
+            } catch (error) {
+                console.error('Error loading agent summary:', error);
+                agentSummary = null;
+            }
+        }
+
+        async function loadRegressionSummary(regressionId) {
+            if (!regressionId) {
+                regressionSummary = null;
+                return;
+            }
+
+            if (regressionCache.has(regressionId)) {
+                regressionSummary = regressionCache.get(regressionId);
+                return;
+            }
+
+            try {
+                const response = await fetch(`/v1/api/regression-tests/${regressionId}`);
+                if (!response.ok) {
+                    if (response.status === 404) {
+                        regressionSummary = null;
+                        return;
+                    }
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                regressionCache.set(regressionId, data);
+                regressionSummary = data;
+            } catch (error) {
+                console.error('Error loading regression summary:', error);
+                regressionSummary = null;
+            }
+        }
+
         function setupModelSettingsCollapse(log) {
             const modelSettingsCollapse = document.getElementById('modelSettingsCollapse');
             const modelSettingsChevron = document.getElementById('modelSettingsChevron');
@@ -638,6 +721,98 @@
         // Helper functions
         function findTestCaseById(testCaseId) {
             return testCasesData.find(tc => tc.id === testCaseId);
+        }
+
+        function formatAgentSummary(agentId) {
+            if (!agentId) {
+                return '<span class="text-muted">Unknown agent</span>';
+            }
+
+            const summary = agentCache.get(agentId) || agentSummary;
+            if (!summary) {
+                return `<span class="badge bg-secondary">${escapeHtml(agentId)}</span>`;
+            }
+
+            const encodedAgentId = encodeURIComponent(agentId);
+            const agentName = summary.name ? escapeHtml(summary.name) : 'Unnamed agent';
+            const description = summary.description ? `<div class="text-muted small mt-1">${escapeHtml(summary.description)}</div>` : '';
+
+            return `
+                <div class="d-flex flex-column">
+                    <div>
+                        <span class="badge bg-primary">${agentName}</span>
+                        <small class="text-muted ms-2">${escapeHtml(agentId)}</small>
+                    </div>
+                    ${description}
+                    <div class="mt-2 small">
+                        <a href="/test-cases?agentId=${encodedAgentId}" class="text-decoration-none" target="_blank">
+                            View test cases for this agent
+                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                        </a>
+                        <span class="text-muted mx-1">•</span>
+                        <a href="/agents" class="text-decoration-none" target="_blank">
+                            Manage agents
+                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                        </a>
+                    </div>
+                </div>
+            `;
+        }
+
+        function formatRegressionSummary(regressionId) {
+            if (!regressionId) {
+                return '<span class="text-muted">Ad-hoc execution</span>';
+            }
+
+            const summary = regressionCache.get(regressionId) || regressionSummary;
+            const encodedRegressionId = encodeURIComponent(regressionId);
+
+            if (!summary) {
+                return `<a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">${escapeHtml(regressionId)}<i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i></a>`;
+            }
+
+            const labelParts = [];
+            if (summary.agent && summary.agent.name) {
+                labelParts.push(summary.agent.name);
+            }
+            if (summary.status) {
+                labelParts.push(summary.status);
+            }
+
+            const label = labelParts.length > 0 ? labelParts.join(' · ') : regressionId;
+            const successCount = summary.success_count ?? 0;
+            const failedCount = summary.failed_count ?? 0;
+            const totalCount = summary.total_count ?? successCount + failedCount;
+            const counts = `${successCount} passed · ${failedCount} failed (total ${totalCount})`;
+            const timing = summary.completed_at
+                ? `Completed ${escapeHtml(formatDate(summary.completed_at))}`
+                : summary.started_at
+                    ? `Started ${escapeHtml(formatDate(summary.started_at))}`
+                    : '';
+            const errorInfo = summary.error_message
+                ? `<div class="text-danger small mt-1">${escapeHtml(summary.error_message)}</div>`
+                : '';
+
+            return `
+                <div class="d-flex flex-column">
+                    <div>
+                        <a href="/regression-tests/${encodedRegressionId}" class="text-decoration-none" target="_blank">
+                            ${escapeHtml(label)}
+                            <i class="fas fa-external-link-alt ms-1" style="font-size: 0.8em;"></i>
+                        </a>
+                    </div>
+                    <div class="text-muted small">${escapeHtml(counts)}</div>
+                    ${timing ? `<div class="text-muted small">${timing}</div>` : ''}
+                    ${errorInfo}
+                </div>
+            `;
+        }
+
+        function formatResponseTime(value) {
+            if (value === null || value === undefined) {
+                return '—';
+            }
+            return `${value}ms`;
         }
 
         function hideLoading() {
@@ -720,7 +895,8 @@
 
         function reExecuteTest() {
             if (currentLog) {
-                window.location.href = `/test-execution?testCaseId=${currentLog.test_case_id}`;
+                const agentParam = currentLog.agent_id ? `&agentId=${encodeURIComponent(currentLog.agent_id)}` : '';
+                window.location.href = `/test-execution?testCaseId=${currentLog.test_case_id}${agentParam}`;
             }
         }
 

--- a/templates/test_log_detail.html
+++ b/templates/test_log_detail.html
@@ -815,8 +815,7 @@
 
             function reExecuteTest() {
                 if (currentLog) {
-                    const agentParam = currentLog.agent_id ? `&agentId=${encodeURIComponent(currentLog.agent_id)}` : '';
-                    window.location.href = `/test-execution?testCaseId=${currentLog.test_case_id}${agentParam}`;
+                    window.location.href = `/test-execution?logId=${currentLog.id}`;
                 }
             }
 

--- a/templates/test_logs.html
+++ b/templates/test_logs.html
@@ -380,13 +380,8 @@
                     <select class="form-select form-select-sm" id="regressionFilter" style="width: 200px;">
                         <option value="">All Regressions</option>
                     </select>
-                    <select class="form-select form-select-sm ms-auto" id="limitSelect" style="width: 120px;">
-                        <option value="50">50 logs</option>
-                        <option value="100" selected>100 logs</option>
-                        <option value="200">200 logs</option>
-                    </select>
-                    <button class="btn btn-primary btn-sm px-4" onclick="applyFilters()">
-                        <i class="fas fa-search me-1"></i>Apply
+                    <button class="btn btn-outline-secondary btn-sm ms-auto" id="clearFiltersBtn">
+                        <i class="fas fa-eraser me-1"></i>Clear
                     </button>
                 </div>
             </div>

--- a/templates/test_logs.html
+++ b/templates/test_logs.html
@@ -1,374 +1,272 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Test Logs - LLM Replay System</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <style>
-        :root {
-            --primary-color: #2563eb;
-            --primary-hover: #1d4ed8;
-            --secondary-color: #64748b;
-            --success-color: #059669;
-            --warning-color: #d97706;
-            --danger-color: #dc2626;
-            --background-color: #f8fafc;
-            --card-background: #ffffff;
-            --border-color: #e2e8f0;
-            --text-primary: #1e293b;
-            --text-secondary: #64748b;
-            --text-muted: #94a3b8;
-        }
+{% block page_title %}Test Logs - LLM Replay System{% endblock %}
 
-        body {
-            background-color: var(--background-color);
-            color: var(--text-primary);
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        }
+{% block extra_css %}
+<style>
+    /* Page Header */
+    .page-title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        /* Navigation Styles */
-        .navbar {
-            background: var(--card-background) !important;
-            border-bottom: 1px solid var(--border-color);
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            padding: 1rem 0;
-        }
+    .page-subtitle {
+        color: var(--text-secondary);
+        font-size: 1rem;
+    }
 
-        .navbar-brand {
-            font-weight: 700;
-            color: var(--text-primary) !important;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
+    /* Card Styles */
+    .card {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+        transition: all 0.2s ease;
+    }
 
-        .navbar-brand i {
-            color: var(--primary-color);
-            font-size: 1.5rem;
-        }
+    .card:hover {
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
 
-        .brand-text {
-            display: flex;
-            flex-direction: column;
-        }
+    .card-header {
+        background: transparent;
+        border-bottom: 1px solid var(--border-color);
+        padding: 1.5rem;
+    }
 
-        .brand-title {
-            font-size: 1.25rem;
-            font-weight: 700;
-            line-height: 1.2;
-        }
+    .card-body {
+        padding: 1.5rem;
+    }
 
-        .brand-subtitle {
-            font-size: 0.75rem;
-            font-weight: 400;
-            color: var(--text-muted) !important;
-            line-height: 1.1;
-        }
+    .card-title {
+        font-weight: 600;
+        color: var(--text-primary);
+        font-size: 1.125rem;
+    }
 
-        .navbar-nav .nav-link {
-            font-weight: 500;
-            color: var(--text-secondary) !important;
-            padding: 0.5rem 1rem !important;
-            border-radius: 0.375rem;
-            transition: all 0.2s ease;
-        }
+    /* Button Styles */
+    .btn-primary {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        padding: 0.625rem 1.25rem;
+        border-radius: 0.5rem;
+        transition: all 0.2s ease;
+    }
 
-        .navbar-nav .nav-link:hover {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-        }
+    .btn-primary:hover {
+        background-color: var(--primary-hover);
+        border-color: var(--primary-hover);
+        transform: translateY(-1px);
+    }
 
-        .navbar-nav .nav-link.active {
-            color: var(--primary-color) !important;
-            background-color: rgba(37, 99, 235, 0.1);
-            font-weight: 600;
-        }
+    .btn-outline-primary {
+        color: var(--primary-color);
+        border-color: var(--primary-color);
+        font-weight: 500;
+        border-radius: 0.5rem;
+    }
 
-        /* Page Header */
-        .page-title {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
+    .btn-outline-primary:hover {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+    }
 
-        .page-subtitle {
-            color: var(--text-secondary);
-            font-size: 1rem;
-        }
+    /* Form Styles */
+    .form-label {
+        font-weight: 500;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        /* Card Styles */
-        .card {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-            transition: all 0.2s ease;
-        }
+    .form-control,
+    .form-select {
+        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        padding: 0.625rem 0.75rem;
+        transition: all 0.2s ease;
+        background-color: var(--card-background);
+    }
 
-        .card:hover {
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-        }
+    .form-control:focus,
+    .form-select:focus {
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
 
-        .card-header {
-            background: transparent;
-            border-bottom: 1px solid var(--border-color);
-            padding: 1.5rem;
-        }
+    .form-label-sm {
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--text-secondary);
+    }
 
-        .card-body {
-            padding: 1.5rem;
-        }
+    /* Table Styles */
+    .table-container {
+        background: var(--card-background);
+        border-radius: 0.75rem;
+        overflow: hidden;
+        border: 1px solid var(--border-color);
+    }
 
-        .card-title {
-            font-weight: 600;
-            color: var(--text-primary);
-            font-size: 1.125rem;
-        }
+    .table {
+        margin-bottom: 0;
+    }
 
-        /* Button Styles */
-        .btn-primary {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            padding: 0.625rem 1.25rem;
-            border-radius: 0.5rem;
-            transition: all 0.2s ease;
-        }
+    .table th {
+        background-color: #f8fafc;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 1rem;
+        font-size: 0.875rem;
+    }
 
-        .btn-primary:hover {
-            background-color: var(--primary-hover);
-            border-color: var(--primary-hover);
-            transform: translateY(-1px);
-        }
+    .table td {
+        padding: 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
 
-        .btn-outline-primary {
-            color: var(--primary-color);
-            border-color: var(--primary-color);
-            font-weight: 500;
-            border-radius: 0.5rem;
-        }
+    .table tbody tr {
+        transition: background-color 0.2s ease;
+    }
 
-        .btn-outline-primary:hover {
-            background-color: var(--primary-color);
-            border-color: var(--primary-color);
-        }
+    .table tbody tr:hover {
+        background-color: #f8fafc;
+    }
 
-        /* Form Styles */
-        .form-label {
-            font-weight: 500;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
+    .table tbody tr:last-child td {
+        border-bottom: none;
+    }
 
-        .form-control,
-        .form-select {
-            border-radius: 0.5rem;
-            border: 1px solid var(--border-color);
-            padding: 0.625rem 0.75rem;
-            transition: all 0.2s ease;
-            background-color: var(--card-background);
-        }
+    /* Status Styles */
+    .status-success {
+        color: var(--success-color);
+    }
 
-        .form-control:focus,
-        .form-select:focus {
-            border-color: var(--primary-color);
-            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-        }
+    .status-failed {
+        color: var(--danger-color);
+    }
 
-        .form-label-sm {
-            font-size: 0.75rem;
-            font-weight: 500;
-            color: var(--text-secondary);
-        }
+    /* Badge Styles */
+    .badge {
+        font-weight: 500;
+        padding: 0.375rem 0.75rem;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+    }
 
-        /* Table Styles */
-        .table-container {
-            background: var(--card-background);
-            border-radius: 0.75rem;
-            overflow: hidden;
-            border: 1px solid var(--border-color);
-        }
+    .badge.bg-success {
+        background-color: var(--success-color) !important;
+    }
 
-        .table {
-            margin-bottom: 0;
-        }
+    .badge.bg-danger {
+        background-color: var(--danger-color) !important;
+    }
 
-        .table th {
-            background-color: #f8fafc;
-            border-bottom: 1px solid var(--border-color);
-            font-weight: 600;
-            color: var(--text-primary);
-            padding: 1rem;
-            font-size: 0.875rem;
-        }
+    /* Filter Controls */
+    .filter-controls {
+        background: var(--card-background);
+        border: 1px solid var(--border-color);
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+    }
 
-        .table td {
-            padding: 1rem;
-            border-bottom: 1px solid #f1f5f9;
-            vertical-align: middle;
-        }
+    /* Empty State */
+    .empty-state {
+        text-align: center;
+        padding: 4rem 2rem;
+        color: var(--text-secondary);
+    }
 
-        .table tbody tr {
-            transition: background-color 0.2s ease;
-        }
+    .empty-state .empty-icon {
+        width: 4rem;
+        height: 4rem;
+        background-color: #f1f5f9;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 auto 1.5rem;
+    }
 
-        .table tbody tr:hover {
-            background-color: #f8fafc;
-        }
+    .empty-state .empty-icon i {
+        font-size: 1.5rem;
+        color: var(--text-muted);
+    }
 
-        .table tbody tr:last-child td {
-            border-bottom: none;
-        }
+    .empty-state h3 {
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.5rem;
+    }
 
-        /* Status Styles */
-        .status-success {
-            color: var(--success-color);
-        }
+    .empty-state p {
+        color: var(--text-secondary);
+        margin-bottom: 1.5rem;
+    }
 
-        .status-failed {
-            color: var(--danger-color);
-        }
+    /* Loading State */
+    .loading-state {
+        text-align: center;
+        padding: 3rem 2rem;
+    }
 
-        /* Badge Styles */
-        .badge {
-            font-weight: 500;
-            padding: 0.375rem 0.75rem;
-            border-radius: 0.375rem;
-            font-size: 0.75rem;
-        }
+    .loading-spinner {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: var(--primary-color);
+    }
 
-        .badge.bg-success {
-            background-color: var(--success-color) !important;
-        }
+    .loading-spinner .spinner-border {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
 
-        .badge.bg-danger {
-            background-color: var(--danger-color) !important;
-        }
+    /* Modal Enhancements */
+    .modal-content {
+        border-radius: 0.75rem;
+        border: 1px solid var(--border-color);
+        box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+    }
 
-        /* Filter Controls */
-        .filter-controls {
-            background: var(--card-background);
-            border: 1px solid var(--border-color);
-            border-radius: 0.75rem;
-            padding: 1.5rem;
-        }
+    .modal-header {
+        border-bottom: 1px solid var(--border-color);
+        padding: 1.5rem;
+    }
 
-        /* Empty State */
-        .empty-state {
-            text-align: center;
-            padding: 4rem 2rem;
-            color: var(--text-secondary);
-        }
+    .modal-title {
+        font-weight: 600;
+        color: var(--text-primary);
+    }
 
-        .empty-state .empty-icon {
-            width: 4rem;
-            height: 4rem;
-            background-color: #f1f5f9;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin: 0 auto 1.5rem;
-        }
+    .modal-body {
+        padding: 1.5rem;
+    }
 
-        .empty-state .empty-icon i {
-            font-size: 1.5rem;
-            color: var(--text-muted);
-        }
+    .modal-footer {
+        border-top: 1px solid var(--border-color);
+        padding: 1.5rem;
+    }
 
-        .empty-state h3 {
-            font-weight: 600;
-            color: var(--text-primary);
-            margin-bottom: 0.5rem;
-        }
+    /* Response Preview */
+    .response-preview {
+        max-height: 300px;
+        overflow-y: auto;
+        font-size: 0.875rem;
+        background-color: #f8fafc;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        border: 1px solid var(--border-color);
+        font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+    }
+</style>
+{% endblock %}
 
-        .empty-state p {
-            color: var(--text-secondary);
-            margin-bottom: 1.5rem;
-        }
-
-        /* Loading State */
-        .loading-state {
-            text-align: center;
-            padding: 3rem 2rem;
-        }
-
-        .loading-spinner {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.75rem;
-            color: var(--primary-color);
-        }
-
-        .loading-spinner .spinner-border {
-            width: 1.25rem;
-            height: 1.25rem;
-        }
-
-        /* Modal Enhancements */
-        .modal-content {
-            border-radius: 0.75rem;
-            border: 1px solid var(--border-color);
-            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
-        }
-
-        .modal-header {
-            border-bottom: 1px solid var(--border-color);
-            padding: 1.5rem;
-        }
-
-        .modal-title {
-            font-weight: 600;
-            color: var(--text-primary);
-        }
-
-        .modal-body {
-            padding: 1.5rem;
-        }
-
-        .modal-footer {
-            border-top: 1px solid var(--border-color);
-            padding: 1.5rem;
-        }
-
-        /* Response Preview */
-        .response-preview {
-            max-height: 300px;
-            overflow-y: auto;
-            font-size: 0.875rem;
-            background-color: #f8fafc;
-            padding: 1rem;
-            border-radius: 0.5rem;
-            border: 1px solid var(--border-color);
-            font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
-        }
-    </style>
-</head>
-
-<body>
-    <nav class="navbar navbar-expand-lg">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <i class="fas fa-robot"></i>
-                <div class="brand-text">
-                    <span class="brand-title">LLM Replay System</span>
-                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
-                </div>
-            </a>
-            <div class="navbar-nav ms-auto">
-                <a class="nav-link" href="/agents">Agents</a>
-                <a class="nav-link" href="/test-cases">Test Cases</a>
-                <a class="nav-link" href="/regression-tests">Regression Tests</a>
-                <a class="nav-link" href="/test-execution">Execute Tests</a>
-                <a class="nav-link active" href="/test-logs">Test Logs</a>
-            </div>
-        </div>
-    </nav>
-
+{% block content %}
     <div class="container py-4">
         <!-- Header -->
         <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
@@ -495,9 +393,8 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block extra_scripts %}
     <script src="/static/js/test-logs.js?v={{ static_asset_version }}"></script>
-</body>
-
-</html>
+{% endblock %}

--- a/templates/test_logs.html
+++ b/templates/test_logs.html
@@ -50,6 +50,24 @@
             font-size: 1.5rem;
         }
 
+        .brand-text {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .brand-title {
+            font-size: 1.25rem;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .brand-subtitle {
+            font-size: 0.75rem;
+            font-weight: 400;
+            color: var(--text-muted) !important;
+            line-height: 1.1;
+        }
+
         .navbar-nav .nav-link {
             font-weight: 500;
             color: var(--text-secondary) !important;
@@ -336,7 +354,10 @@
         <div class="container">
             <a class="navbar-brand" href="/">
                 <i class="fas fa-robot"></i>
-                <span>LLM Replay System</span>
+                <div class="brand-text">
+                    <span class="brand-title">LLM Replay System</span>
+                    <span class="brand-subtitle">working with pydantic-ai and logfire</span>
+                </div>
             </a>
             <div class="navbar-nav ms-auto">
                 <a class="nav-link" href="/agents">Agents</a>
@@ -350,11 +371,18 @@
 
     <div class="container py-4">
         <!-- Header -->
-        <div class="mb-4">
-            <h1 class="page-title">
-                <i class="fas fa-history me-3"></i>Test Logs
-            </h1>
-            <p class="page-subtitle">View and analyze test execution history</p>
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4">
+            <div class="mb-3 mb-lg-0">
+                <h1 class="page-title">
+                    <i class="fas fa-history me-3"></i>Test Logs
+                </h1>
+                <p class="page-subtitle mb-0">View and analyze test execution history</p>
+            </div>
+            <div class="d-flex align-items-center gap-2">
+                <button class="btn btn-outline-primary" id="refreshTestLogsBtn">
+                    <i class="fas fa-refresh me-2"></i>Refresh
+                </button>
+            </div>
         </div>
 
 

--- a/templates/test_logs.html
+++ b/templates/test_logs.html
@@ -339,7 +339,9 @@
                 <span>LLM Replay System</span>
             </a>
             <div class="navbar-nav ms-auto">
+                <a class="nav-link" href="/agents">Agents</a>
                 <a class="nav-link" href="/test-cases">Test Cases</a>
+                <a class="nav-link" href="/regression-tests">Regression Tests</a>
                 <a class="nav-link" href="/test-execution">Execute Tests</a>
                 <a class="nav-link active" href="/test-logs">Test Logs</a>
             </div>
@@ -360,25 +362,29 @@
         <!-- Filters -->
         <div class="card mb-3">
             <div class="card-body py-3">
-                <div class="d-flex align-items-center justify-content-between">
-                    <div class="d-flex align-items-center">
-                        <span class="text-muted fw-medium me-5">
-                            <i class="fas fa-filter me-2"></i>Filters:
-                        </span>
-                        <select class="form-select form-select-sm me-5" id="statusFilter" style="width: 160px;">
-                            <option value="">All Statuses</option>
-                            <option value="success">Success</option>
-                            <option value="failed">Failed</option>
-                        </select>
-                        <select class="form-select form-select-sm me-5" id="testCaseFilter" style="width: 220px;">
-                            <option value="">All Test Cases</option>
-                        </select>
-                        <select class="form-select form-select-sm" id="limitSelect" style="width: 120px;">
-                            <option value="50">50 logs</option>
-                            <option value="100" selected>100 logs</option>
-                            <option value="200">200 logs</option>
-                        </select>
-                    </div>
+                <div class="d-flex flex-wrap align-items-center gap-3">
+                    <span class="text-muted fw-medium me-2">
+                        <i class="fas fa-filter me-2"></i>Filters:
+                    </span>
+                    <select class="form-select form-select-sm" id="statusFilter" style="width: 160px;">
+                        <option value="">All Statuses</option>
+                        <option value="success">Success</option>
+                        <option value="failed">Failed</option>
+                    </select>
+                    <select class="form-select form-select-sm" id="agentFilter" style="width: 200px;">
+                        <option value="">All Agents</option>
+                    </select>
+                    <select class="form-select form-select-sm" id="testCaseFilter" style="width: 220px;">
+                        <option value="">All Test Cases</option>
+                    </select>
+                    <select class="form-select form-select-sm" id="regressionFilter" style="width: 200px;">
+                        <option value="">All Regressions</option>
+                    </select>
+                    <select class="form-select form-select-sm ms-auto" id="limitSelect" style="width: 120px;">
+                        <option value="50">50 logs</option>
+                        <option value="100" selected>100 logs</option>
+                        <option value="200">200 logs</option>
+                    </select>
                     <button class="btn btn-primary btn-sm px-4" onclick="applyFilters()">
                         <i class="fas fa-search me-1"></i>Apply
                     </button>
@@ -391,12 +397,14 @@
             <table class="table table-hover mb-0" id="testLogsTable">
                 <thead>
                     <tr>
-                        <th style="width: 20%">Test Case</th>
-                        <th style="width: 15%">Model</th>
+                        <th style="width: 18%">Test Case</th>
+                        <th style="width: 16%">Agent</th>
+                        <th style="width: 14%">Regression</th>
                         <th style="width: 12%">Status</th>
-                        <th style="width: 15%">Response Time</th>
-                        <th style="width: 18%">Executed At</th>
-                        <th style="width: 20%">Actions</th>
+                        <th style="width: 12%">Model</th>
+                        <th style="width: 12%">Response Time</th>
+                        <th style="width: 16%">Executed At</th>
+                        <th style="width: 10%">Actions</th>
                     </tr>
                 </thead>
                 <tbody id="testLogsList">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
+
 from src.core.config import settings
+
 
 @pytest.fixture
 def test_settings():

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -6,7 +6,7 @@ import pytest
 from src.services.agent_service import AgentService, AgentUpdateData
 
 
-def test_delete_agent_soft_deletes_cases(monkeypatch):
+def test_delete_agent_soft_deletes_dependencies(monkeypatch):
     service = AgentService()
 
     monkeypatch.setattr(service.store, "soft_delete", lambda agent_id: True)
@@ -14,15 +14,26 @@ def test_delete_agent_soft_deletes_cases(monkeypatch):
     captured = {}
 
     def fake_soft_delete_by_agent(agent_id: str) -> int:
-        captured["agent_id"] = agent_id
+        captured["case_agent_id"] = agent_id
         return 2
 
     monkeypatch.setattr(
         service.test_case_store, "soft_delete_by_agent", fake_soft_delete_by_agent
     )
 
+    def fake_soft_delete_regressions(agent_id: str) -> int:
+        captured["regression_agent_id"] = agent_id
+        return 1
+
+    monkeypatch.setattr(
+        service.regression_test_store,
+        "soft_delete_by_agent",
+        fake_soft_delete_regressions,
+    )
+
     assert service.delete_agent("agent-123") is True
-    assert captured["agent_id"] == "agent-123"
+    assert captured["case_agent_id"] == "agent-123"
+    assert captured["regression_agent_id"] == "agent-123"
 
 
 def test_ensure_default_agent_creates_when_missing(monkeypatch):

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -1,0 +1,44 @@
+from src.services.agent_service import AgentService
+
+
+def test_delete_agent_soft_deletes_cases(monkeypatch):
+    service = AgentService()
+
+    monkeypatch.setattr(service.store, "soft_delete", lambda agent_id: True)
+
+    captured = {}
+
+    def fake_soft_delete_by_agent(agent_id: str) -> int:
+        captured["agent_id"] = agent_id
+        return 2
+
+    monkeypatch.setattr(
+        service.test_case_store, "soft_delete_by_agent", fake_soft_delete_by_agent
+    )
+
+    assert service.delete_agent("agent-123") is True
+    assert captured["agent_id"] == "agent-123"
+
+
+def test_ensure_default_agent_creates_when_missing(monkeypatch):
+    service = AgentService()
+
+    monkeypatch.setattr(service.store, "get_by_id", lambda *_args, **_kwargs: None)
+
+    created = {}
+
+    def fake_create(agent):
+        created["agent"] = agent
+        return agent
+
+    monkeypatch.setattr(service.store, "create", fake_create)
+
+    default_agent = service.ensure_default_agent_exists()
+    assert default_agent.id == service.DEFAULT_AGENT_ID
+    assert created["agent"].name == "Default Agent"
+
+
+def test_get_agent_summary_handles_missing(monkeypatch):
+    service = AgentService()
+    monkeypatch.setattr(service.store, "get_by_id", lambda *_args, **_kwargs: None)
+    assert service.get_agent_summary("missing") is None

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -36,24 +36,6 @@ def test_delete_agent_soft_deletes_dependencies(monkeypatch):
     assert captured["regression_agent_id"] == "agent-123"
 
 
-def test_ensure_default_agent_creates_when_missing(monkeypatch):
-    service = AgentService()
-
-    monkeypatch.setattr(service.store, "get_by_id", lambda *_args, **_kwargs: None)
-
-    created = {}
-
-    def fake_create(agent):
-        created["agent"] = agent
-        return agent
-
-    monkeypatch.setattr(service.store, "create", fake_create)
-
-    default_agent = service.ensure_default_agent_exists()
-    assert default_agent.id == service.DEFAULT_AGENT_ID
-    assert created["agent"].name == "Default Agent"
-
-
 def test_get_agent_summary_handles_missing(monkeypatch):
     service = AgentService()
     monkeypatch.setattr(service.store, "get_by_id", lambda *_args, **_kwargs: None)

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -1,4 +1,7 @@
-from src.services.agent_service import AgentService
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from src.services.agent_service import AgentService, AgentUpdateData
 
 
 def test_delete_agent_soft_deletes_cases(monkeypatch):
@@ -42,3 +45,40 @@ def test_get_agent_summary_handles_missing(monkeypatch):
     service = AgentService()
     monkeypatch.setattr(service.store, "get_by_id", lambda *_args, **_kwargs: None)
     assert service.get_agent_summary("missing") is None
+
+
+def test_update_agent_soft_delete_cascade(monkeypatch):
+    service = AgentService()
+
+    agent = SimpleNamespace(
+        id="agent-123",
+        name="Agent 123",
+        description=None,
+        default_model_name=None,
+        default_system_prompt=None,
+        default_model_settings=None,
+        is_deleted=False,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    monkeypatch.setattr(
+        service.store, "get_by_id", lambda *_args, **_kwargs: agent
+    )
+
+    monkeypatch.setattr(service.store, "update", lambda obj: obj)
+
+    captured = {}
+
+    def fake_soft_delete_by_agent(agent_id: str) -> int:
+        captured["agent_id"] = agent_id
+        return 1
+
+    monkeypatch.setattr(
+        service.test_case_store, "soft_delete_by_agent", fake_soft_delete_by_agent
+    )
+
+    result = service.update_agent("agent-123", AgentUpdateData(is_deleted=True))
+
+    assert result.is_deleted is True
+    assert captured["agent_id"] == "agent-123"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 import pytest
+
 from main import create_app
+
 
 def test_create_app():
     app = create_app()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,3 @@
-import pytest
-
 from main import create_app
 
 

--- a/tests/test_regression_test_service.py
+++ b/tests/test_regression_test_service.py
@@ -43,9 +43,9 @@ async def test_run_regression_with_no_cases(monkeypatch):
 
     request = RegressionTestCreateData(
         agent_id="agent-1",
-        model_name="model",
-        system_prompt="prompt",
-        model_settings={},
+        model_name_override="model",
+        system_prompt_override="prompt",
+        model_settings_override={},
     )
 
     result = await service.run_regression_test(request)
@@ -103,9 +103,9 @@ async def test_run_regression_counts_results(monkeypatch):
 
     request = RegressionTestCreateData(
         agent_id="agent-1",
-        model_name="override-model",
-        system_prompt="override",
-        model_settings={},
+        model_name_override="override-model",
+        system_prompt_override="override",
+        model_settings_override={},
     )
 
     result = await service.run_regression_test(request)

--- a/tests/test_regression_test_service.py
+++ b/tests/test_regression_test_service.py
@@ -1,0 +1,115 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.regression_test_service import (
+    RegressionTestCreateData,
+    RegressionTestService,
+)
+from src.services.test_execution_service import TestExecutionResult
+
+
+@pytest.mark.asyncio
+async def test_run_regression_with_no_cases(monkeypatch):
+    service = RegressionTestService()
+
+    agent = SimpleNamespace(
+        id="agent-1",
+        is_deleted=False,
+        default_model_name="model",
+        default_system_prompt="prompt",
+        default_model_settings={"temperature": 0.2},
+    )
+
+    monkeypatch.setattr(
+        service.agent_service,
+        "get_active_agent_or_raise",
+        lambda agent_id: agent,
+    )
+    monkeypatch.setattr(
+        service.agent_service,
+        "get_agent_summary",
+        lambda agent_id: None,
+    )
+    monkeypatch.setattr(
+        service.test_case_service.store,
+        "get_by_agent",
+        lambda agent_id: [],
+    )
+
+    created = {}
+    monkeypatch.setattr(service.store, "create", lambda record: record)
+    monkeypatch.setattr(service.store, "update", lambda record: record)
+
+    request = RegressionTestCreateData(
+        agent_id="agent-1",
+        model_name="model",
+        system_prompt="prompt",
+        model_settings={},
+    )
+
+    result = await service.run_regression_test(request)
+    assert result.status == "completed"
+    assert result.total_count == 0
+    assert result.success_count == 0
+    assert result.failed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_regression_counts_results(monkeypatch):
+    service = RegressionTestService()
+
+    agent = SimpleNamespace(
+        id="agent-1",
+        is_deleted=False,
+        default_model_name="model",
+        default_system_prompt="prompt",
+        default_model_settings={},
+    )
+
+    test_cases = [
+        SimpleNamespace(id="case-1", agent_id="agent-1"),
+        SimpleNamespace(id="case-2", agent_id="agent-1"),
+    ]
+
+    monkeypatch.setattr(
+        service.agent_service,
+        "get_active_agent_or_raise",
+        lambda agent_id: agent,
+    )
+    monkeypatch.setattr(
+        service.agent_service,
+        "get_agent_summary",
+        lambda agent_id: None,
+    )
+    monkeypatch.setattr(
+        service.test_case_service.store,
+        "get_by_agent",
+        lambda agent_id: test_cases,
+    )
+    monkeypatch.setattr(service.store, "create", lambda record: record)
+    monkeypatch.setattr(service.store, "update", lambda record: record)
+
+    async def fake_execute(request):
+        if request.test_case_id == "case-1":
+            return TestExecutionResult(status="success")
+        return TestExecutionResult(status="failed", error_message="boom")
+
+    monkeypatch.setattr(
+        service.test_execution_service,
+        "execute_test",
+        fake_execute,
+    )
+
+    request = RegressionTestCreateData(
+        agent_id="agent-1",
+        model_name="override-model",
+        system_prompt="override",
+        model_settings={},
+    )
+
+    result = await service.run_regression_test(request)
+    assert result.total_count == 2
+    assert result.success_count == 1
+    assert result.failed_count == 1
+    assert result.status == "failed"

--- a/tests/test_regression_test_service.py
+++ b/tests/test_regression_test_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +16,7 @@ async def test_run_regression_with_no_cases(monkeypatch):
 
     agent = SimpleNamespace(
         id="agent-1",
+        name="Agent 1",
         is_deleted=False,
         default_model_name="model",
         default_system_prompt="prompt",
@@ -37,9 +39,18 @@ async def test_run_regression_with_no_cases(monkeypatch):
         lambda agent_id: [],
     )
 
-    created = {}
-    monkeypatch.setattr(service.store, "create", lambda record: record)
-    monkeypatch.setattr(service.store, "update", lambda record: record)
+    def fake_create(record):
+        now = datetime.now(timezone.utc)
+        record.created_at = now
+        record.updated_at = now
+        return record
+
+    def fake_update(record):
+        record.updated_at = datetime.now(timezone.utc)
+        return record
+
+    monkeypatch.setattr(service.store, "create", fake_create)
+    monkeypatch.setattr(service.store, "update", fake_update)
 
     request = RegressionTestCreateData(
         agent_id="agent-1",
@@ -61,6 +72,7 @@ async def test_run_regression_counts_results(monkeypatch):
 
     agent = SimpleNamespace(
         id="agent-1",
+        name="Agent 1",
         is_deleted=False,
         default_model_name="model",
         default_system_prompt="prompt",
@@ -87,8 +99,18 @@ async def test_run_regression_counts_results(monkeypatch):
         "get_by_agent",
         lambda agent_id: test_cases,
     )
-    monkeypatch.setattr(service.store, "create", lambda record: record)
-    monkeypatch.setattr(service.store, "update", lambda record: record)
+    def fake_create(record):
+        now = datetime.now(timezone.utc)
+        record.created_at = now
+        record.updated_at = now
+        return record
+
+    def fake_update(record):
+        record.updated_at = datetime.now(timezone.utc)
+        return record
+
+    monkeypatch.setattr(service.store, "create", fake_create)
+    monkeypatch.setattr(service.store, "update", fake_update)
 
     async def fake_execute(request):
         if request.test_case_id == "case-1":

--- a/tests/test_test_case_service.py
+++ b/tests/test_test_case_service.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 
 from src.services.test_case_service import TestCaseService, TestCaseUpdateData
 
-
 TestCaseService.__test__ = False
 TestCaseUpdateData.__test__ = False
 
@@ -11,6 +10,8 @@ TestCaseUpdateData.__test__ = False
 def _build_test_case(**overrides):
     base = {
         "id": "case-1",
+        "agent_id": "agent-1",
+        "agent": None,
         "name": "Sample",
         "description": "desc",
         "raw_data": {"messages": []},

--- a/tests/test_test_log_store.py
+++ b/tests/test_test_log_store.py
@@ -65,7 +65,10 @@ def _has_filter(filters, column_name: str, table_name: str) -> bool:
     for condition in filters:
         left = getattr(condition, "left", None)
         table = getattr(left, "table", None)
-        if getattr(left, "key", None) == column_name and getattr(table, "name", None) == table_name:
+        if (
+            getattr(left, "key", None) == column_name
+            and getattr(table, "name", None) == table_name
+        ):
             return True
     return False
 
@@ -85,7 +88,9 @@ def test_get_all_excludes_soft_deleted_cases(monkeypatch: pytest.MonkeyPatch) ->
     assert _has_filter(query.filters, "is_deleted", "test_cases")
 
 
-def test_get_filtered_excludes_soft_deleted_cases(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_filtered_excludes_soft_deleted_cases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     store = TestLogStore()
     fake_results = [object()]
     query = FakeQuery(results=fake_results)
@@ -102,3 +107,17 @@ def test_get_filtered_excludes_soft_deleted_cases(monkeypatch: pytest.MonkeyPatc
     assert _has_filter(query.filters, "is_deleted", "test_cases")
     assert _has_filter(query.filters, "status", "test_logs")
     assert _has_filter(query.filters, "test_case_id", "test_logs")
+
+
+def test_get_filtered_supports_agent_and_regression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = TestLogStore()
+    query = FakeQuery(results=[object()])
+    _patch_database_session(monkeypatch, query)
+
+    result = store.get_filtered(agent_id="agent-7", regression_test_id="reg-2")
+
+    assert result
+    assert _has_filter(query.filters, "agent_id", "test_logs")
+    assert _has_filter(query.filters, "regression_test_id", "test_logs")


### PR DESCRIPTION
## Summary
- add database models, migrations, stores, and services for agents plus regression tests
- expose new FastAPI endpoints and converters for working with agents, regression runs, and enriched test logs
- update existing schemas, execution flows, scripts, and tests to track agent/regression context throughout the stack

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pydantic')*
- black src tests main.py
- isort src tests main.py

------
https://chatgpt.com/codex/tasks/task_e_68ced8a4f4208333969b178137153a93