### PR TITLE
Enhance text display in regression test logs

### DIFF
--- a/templates/regression_test_detail.html
+++ b/templates/regression_test_detail.html
@@ -130,6 +130,8 @@
         font-size: 0.875rem;
         max-height: 320px;
         overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
     }
 
     .logs-card .table {


### PR DESCRIPTION
- Added CSS properties `white-space: pre-wrap` and `word-break: break-word` to improve text wrapping and prevent overflow in the logs card section of the regression test detail template.