### PR TITLE
Add list item response converters and update API endpoints

### DIFF
--- a/src/api/v1/converters/__init__.py
+++ b/src/api/v1/converters/__init__.py
@@ -6,17 +6,20 @@ Converters between API layer schemas and service layer schemas.
 
 from .agent_converters import (
     convert_agent_create_request,
+    convert_agent_data_to_list_item_response,
     convert_agent_data_to_response,
     convert_agent_summary_to_response,
     convert_agent_update_request,
 )
 from .regression_test_converters import (
     convert_regression_test_create_request,
+    convert_regression_test_data_to_list_item_response,
     convert_regression_test_data_to_response,
 )
 from .settings_converters import convert_evaluation_settings_to_response
 from .test_case_converters import (
     convert_test_case_create_request,
+    convert_test_case_data_to_list_item_response,
     convert_test_case_data_to_response,
     convert_test_case_update_request,
 )
@@ -24,20 +27,27 @@ from .test_execution_converters import (
     convert_test_execution_request,
     convert_test_execution_result_to_response,
 )
-from .test_log_converters import convert_test_log_data_to_response
+from .test_log_converters import (
+    convert_test_log_data_to_list_item_response,
+    convert_test_log_data_to_response,
+)
 
 __all__ = [
     "convert_agent_create_request",
     "convert_agent_update_request",
     "convert_agent_data_to_response",
+    "convert_agent_data_to_list_item_response",
     "convert_agent_summary_to_response",
     "convert_regression_test_create_request",
     "convert_regression_test_data_to_response",
+    "convert_regression_test_data_to_list_item_response",
     "convert_evaluation_settings_to_response",
     "convert_test_case_create_request",
     "convert_test_case_update_request",
     "convert_test_case_data_to_response",
+    "convert_test_case_data_to_list_item_response",
     "convert_test_execution_request",
     "convert_test_execution_result_to_response",
     "convert_test_log_data_to_response",
+    "convert_test_log_data_to_list_item_response",
 ]

--- a/src/api/v1/converters/agent_converters.py
+++ b/src/api/v1/converters/agent_converters.py
@@ -2,6 +2,7 @@
 
 from src.api.v1.schemas.requests import AgentCreateRequest, AgentUpdateRequest
 from src.api.v1.schemas.responses.agent_responses import (
+    AgentListItemResponse,
     AgentResponse,
     AgentSummaryResponse,
 )
@@ -43,6 +44,23 @@ def convert_agent_data_to_response(data: AgentData) -> AgentResponse:
     return AgentResponse.model_validate(data)
 
 
+def convert_agent_data_to_list_item_response(
+    data: AgentData,
+) -> AgentListItemResponse:
+    """Convert service data to lightweight list response."""
+
+    return AgentListItemResponse(
+        id=data.id,
+        name=data.name,
+        description=data.description,
+        default_model_name=data.default_model_name,
+        default_system_prompt=data.default_system_prompt,
+        default_model_settings=data.default_model_settings,
+        is_deleted=data.is_deleted,
+        created_at=data.created_at,
+    )
+
+
 def convert_agent_summary_to_response(
     summary: AgentSummary | None,
 ) -> AgentSummaryResponse | None:
@@ -57,5 +75,6 @@ __all__ = [
     "convert_agent_create_request",
     "convert_agent_update_request",
     "convert_agent_data_to_response",
+    "convert_agent_data_to_list_item_response",
     "convert_agent_summary_to_response",
 ]

--- a/src/api/v1/converters/regression_test_converters.py
+++ b/src/api/v1/converters/regression_test_converters.py
@@ -1,7 +1,10 @@
 """Regression test API converters."""
 
 from src.api.v1.schemas.requests import RegressionTestCreateRequest
-from src.api.v1.schemas.responses import RegressionTestResponse
+from src.api.v1.schemas.responses import (
+    RegressionTestListItemResponse,
+    RegressionTestResponse,
+)
 from src.services.regression_test_service import (
     RegressionTestCreateData,
     RegressionTestData,
@@ -50,7 +53,28 @@ def convert_regression_test_data_to_response(
     )
 
 
+def convert_regression_test_data_to_list_item_response(
+    data: RegressionTestData,
+) -> RegressionTestListItemResponse:
+    """Convert regression data to lightweight list response."""
+
+    return RegressionTestListItemResponse(
+        id=data.id,
+        agent_id=data.agent_id,
+        status=data.status,
+        model_name_override=data.model_name_override,
+        system_prompt_override=data.system_prompt_override,
+        model_settings_override=data.model_settings_override,
+        total_count=data.total_count,
+        passed_count=data.passed_count,
+        declined_count=data.declined_count,
+        created_at=data.created_at,
+        agent=convert_agent_summary_to_response(data.agent),
+    )
+
+
 __all__ = [
     "convert_regression_test_create_request",
     "convert_regression_test_data_to_response",
+    "convert_regression_test_data_to_list_item_response",
 ]

--- a/src/api/v1/converters/test_case_converters.py
+++ b/src/api/v1/converters/test_case_converters.py
@@ -9,6 +9,7 @@ from src.api.v1.schemas.responses.test_case_responses import (
     AgentSummaryResponse as TestCaseAgentSummaryResponse,
 )
 from src.api.v1.schemas.responses.test_case_responses import (
+    TestCaseListItemResponse,
     TestCaseResponse,
 )
 from src.services.test_case_service import (
@@ -72,4 +73,26 @@ def convert_test_case_data_to_response(data: TestCaseData) -> TestCaseResponse:
         is_deleted=data.is_deleted,
         created_at=data.created_at,
         updated_at=data.updated_at,
+    )
+
+
+def convert_test_case_data_to_list_item_response(
+    data: TestCaseData,
+) -> TestCaseListItemResponse:
+    """Convert service layer data to lightweight list response."""
+
+    return TestCaseListItemResponse(
+        id=data.id,
+        name=data.name,
+        description=data.description,
+        last_user_message=data.last_user_message,
+        response_example=data.response_example,
+        response_expectation=data.response_expectation,
+        agent_id=data.agent_id,
+        agent=(
+            TestCaseAgentSummaryResponse.model_validate(data.agent)
+            if data.agent
+            else None
+        ),
+        created_at=data.created_at,
     )

--- a/src/api/v1/converters/test_execution_converters.py
+++ b/src/api/v1/converters/test_execution_converters.py
@@ -6,7 +6,7 @@ Converters between API layer and service layer schemas for test execution.
 
 from src.api.v1.schemas.requests import TestExecutionRequest
 from src.api.v1.schemas.responses import TestExecutionResponse
-from src.services.test_execution_service import ExecutionResult, ExecutionData
+from src.services.test_execution_service import ExecutionData, ExecutionResult
 
 
 def convert_test_execution_request(request: TestExecutionRequest) -> ExecutionData:

--- a/src/api/v1/converters/test_log_converters.py
+++ b/src/api/v1/converters/test_log_converters.py
@@ -4,7 +4,7 @@ Test Log Converters
 Converters between API layer and service layer schemas for test logs.
 """
 
-from src.api.v1.schemas.responses import TestLogResponse
+from src.api.v1.schemas.responses import TestLogListItemResponse, TestLogResponse
 from src.services.test_log_service import LogData
 
 
@@ -32,3 +32,34 @@ def convert_test_log_data_to_response(data: LogData) -> TestLogResponse:
         error_message=data.error_message,
         created_at=data.created_at,
     )
+
+
+def convert_test_log_data_to_list_item_response(
+    data: LogData,
+) -> TestLogListItemResponse:
+    """Convert service layer log data to lightweight list response."""
+
+    return TestLogListItemResponse(
+        id=data.id,
+        test_case_id=data.test_case_id,
+        agent_id=data.agent_id,
+        regression_test_id=data.regression_test_id,
+        model_name=data.model_name,
+        user_message=data.user_message,
+        llm_response=data.llm_response,
+        response_expectation_snapshot=data.response_expectation_snapshot,
+        response_time_ms=data.response_time_ms,
+        is_passed=data.is_passed,
+        evaluation_feedback=data.evaluation_feedback,
+        evaluation_model_name=data.evaluation_model_name,
+        evaluation_metadata=data.evaluation_metadata,
+        status=data.status,
+        error_message=data.error_message,
+        created_at=data.created_at,
+    )
+
+
+__all__ = [
+    "convert_test_log_data_to_response",
+    "convert_test_log_data_to_list_item_response",
+]

--- a/src/api/v1/endpoints/agents.py
+++ b/src/api/v1/endpoints/agents.py
@@ -6,11 +6,12 @@ from fastapi import APIRouter, HTTPException, Query
 
 from src.api.v1.converters import (
     convert_agent_create_request,
+    convert_agent_data_to_list_item_response,
     convert_agent_data_to_response,
     convert_agent_update_request,
 )
 from src.api.v1.schemas.requests import AgentCreateRequest, AgentUpdateRequest
-from src.api.v1.schemas.responses import AgentResponse
+from src.api.v1.schemas.responses import AgentListItemResponse, AgentResponse
 from src.core.logger import get_logger
 from src.services.agent_service import AgentService
 
@@ -31,7 +32,7 @@ async def create_agent(request: AgentCreateRequest) -> AgentResponse:
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/", response_model=List[AgentResponse])
+@router.get("/", response_model=List[AgentListItemResponse])
 async def list_agents(
     limit: int = Query(20, ge=1, le=1000),
     offset: int = Query(0, ge=0),
@@ -40,14 +41,14 @@ async def list_agents(
         min_length=1,
         description="Filter agents by name using a case-insensitive substring match",
     ),
-) -> List[AgentResponse]:
+) -> List[AgentListItemResponse]:
     try:
         agents = agent_service.list_agents(
             limit=limit,
             offset=offset,
             search=search,
         )
-        return [convert_agent_data_to_response(agent) for agent in agents]
+        return [convert_agent_data_to_list_item_response(agent) for agent in agents]
     except Exception as exc:  # pragma: no cover - defensive logging
         logger.error("API: Failed to list agents: %s", exc)
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/src/api/v1/endpoints/test_cases.py
+++ b/src/api/v1/endpoints/test_cases.py
@@ -10,11 +10,12 @@ from fastapi import APIRouter, HTTPException, Query
 
 from src.api.v1.converters import (
     convert_test_case_create_request,
+    convert_test_case_data_to_list_item_response,
     convert_test_case_data_to_response,
     convert_test_case_update_request,
 )
 from src.api.v1.schemas.requests import TestCaseCreateRequest, TestCaseUpdateRequest
-from src.api.v1.schemas.responses import TestCaseResponse
+from src.api.v1.schemas.responses import TestCaseListItemResponse, TestCaseResponse
 from src.core.logger import get_logger
 from src.services.test_case_service import TestCaseService
 
@@ -55,7 +56,7 @@ async def create_test_case(request: TestCaseCreateRequest):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/", response_model=List[TestCaseResponse])
+@router.get("/", response_model=List[TestCaseListItemResponse])
 async def get_test_cases(
     limit: int = Query(20, ge=1, le=1000),
     offset: int = Query(0, ge=0),
@@ -82,14 +83,14 @@ async def get_test_cases(
             limit=limit, offset=offset, agent_id=agent_id
         )
         logger.debug(f"API: Retrieved {len(result)} test cases")
-        return [convert_test_case_data_to_response(item) for item in result]
+        return [convert_test_case_data_to_list_item_response(item) for item in result]
 
     except Exception as e:
         logger.error(f"API: Failed to get test cases: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/search", response_model=List[TestCaseResponse])
+@router.get("/search", response_model=List[TestCaseListItemResponse])
 async def search_test_cases(
     q: str = Query(..., min_length=1, description="Search query"),
     limit: int = Query(20, ge=1, le=500),
@@ -117,7 +118,7 @@ async def search_test_cases(
             q, limit=limit, offset=offset, agent_id=agent_id
         )
         logger.debug(f"API: Found {len(result)} test cases matching '{q}'")
-        return [convert_test_case_data_to_response(item) for item in result]
+        return [convert_test_case_data_to_list_item_response(item) for item in result]
 
     except Exception as e:
         logger.error(f"API: Failed to search test cases: {e}")

--- a/src/api/v1/endpoints/test_logs.py
+++ b/src/api/v1/endpoints/test_logs.py
@@ -8,8 +8,14 @@ from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 
-from src.api.v1.converters import convert_test_log_data_to_response
-from src.api.v1.schemas.responses.test_log_responses import TestLogResponse
+from src.api.v1.converters import (
+    convert_test_log_data_to_list_item_response,
+    convert_test_log_data_to_response,
+)
+from src.api.v1.schemas.responses.test_log_responses import (
+    TestLogListItemResponse,
+    TestLogResponse,
+)
 from src.core.logger import get_logger
 from src.services.test_log_service import LogService
 
@@ -19,7 +25,7 @@ router = APIRouter(prefix="/api/test-logs", tags=["test-logs"])
 test_log_service = LogService()
 
 
-@router.get("/", response_model=List[TestLogResponse])
+@router.get("/", response_model=List[TestLogListItemResponse])
 async def get_test_logs(
     limit: int = Query(20, ge=1, le=1000, description="Maximum number of results"),
     offset: int = Query(0, ge=0, description="Number of results to skip"),
@@ -50,7 +56,7 @@ async def get_test_logs(
             regression_test_id=regression_test_id,
         )
         logger.debug(f"API: Retrieved {len(result)} test logs")
-        return [convert_test_log_data_to_response(log) for log in result]
+        return [convert_test_log_data_to_list_item_response(log) for log in result]
 
     except Exception as e:
         logger.error(f"API: Failed to get test logs: {e}")
@@ -88,7 +94,7 @@ async def get_test_log(log_id: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/test-case/{test_case_id}", response_model=List[TestLogResponse])
+@router.get("/test-case/{test_case_id}", response_model=List[TestLogListItemResponse])
 async def get_logs_by_test_case(
     test_case_id: str,
     limit: int = Query(20, ge=1, le=1000),
@@ -114,14 +120,14 @@ async def get_logs_by_test_case(
             test_case_id, limit=limit, offset=offset
         )
         logger.debug(f"API: Retrieved {len(result)} logs for test case {test_case_id}")
-        return [convert_test_log_data_to_response(log) for log in result]
+        return [convert_test_log_data_to_list_item_response(log) for log in result]
 
     except Exception as e:
         logger.error(f"API: Failed to get logs for test case {test_case_id}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/filter/status/{status}", response_model=List[TestLogResponse])
+@router.get("/filter/status/{status}", response_model=List[TestLogListItemResponse])
 async def get_logs_by_status(
     status: str,
     limit: int = Query(20, ge=1, le=1000),
@@ -155,14 +161,14 @@ async def get_logs_by_status(
             regression_test_id=regression_test_id,
         )
         logger.debug(f"API: Retrieved {len(result)} logs with status {status}")
-        return [convert_test_log_data_to_response(log) for log in result]
+        return [convert_test_log_data_to_list_item_response(log) for log in result]
 
     except Exception as e:
         logger.error(f"API: Failed to get logs by status {status}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.get("/filter/combined", response_model=List[TestLogResponse])
+@router.get("/filter/combined", response_model=List[TestLogListItemResponse])
 async def get_logs_filtered(
     status: Optional[str] = Query(None, description="Filter by status"),
     test_case_id: Optional[str] = Query(None, description="Filter by test case ID"),
@@ -201,7 +207,7 @@ async def get_logs_filtered(
             offset=offset,
         )
         logger.debug(f"API: Retrieved {len(result)} filtered logs")
-        return [convert_test_log_data_to_response(log) for log in result]
+        return [convert_test_log_data_to_list_item_response(log) for log in result]
 
     except Exception as e:
         logger.error(f"API: Failed to get filtered logs: {e}")
@@ -272,7 +278,9 @@ async def delete_logs_by_test_case(test_case_id: str):
 __all__ = ["router"]
 
 
-@router.get("/regression/{regression_test_id}", response_model=List[TestLogResponse])
+@router.get(
+    "/regression/{regression_test_id}", response_model=List[TestLogListItemResponse]
+)
 async def get_logs_by_regression_test(
     regression_test_id: str,
     limit: int = Query(100, ge=1, le=1000),
@@ -290,7 +298,7 @@ async def get_logs_by_regression_test(
             len(result),
             regression_test_id,
         )
-        return [convert_test_log_data_to_response(log) for log in result]
+        return [convert_test_log_data_to_list_item_response(log) for log in result]
     except Exception as e:
         logger.error(
             "API: Failed to get logs for regression test %s: %s",

--- a/src/api/v1/schemas/responses/__init__.py
+++ b/src/api/v1/schemas/responses/__init__.py
@@ -4,21 +4,28 @@ V1 API Response Schemas
 Response schemas for all API v1 endpoints.
 """
 
-from .agent_responses import AgentResponse, AgentSummaryResponse
+from .agent_responses import AgentListItemResponse, AgentResponse, AgentSummaryResponse
 from .health_response import HealthResponse
-from .regression_test_responses import RegressionTestResponse
+from .regression_test_responses import (
+    RegressionTestListItemResponse,
+    RegressionTestResponse,
+)
 from .settings_responses import EvaluationSettingsResponse
-from .test_case_responses import TestCaseResponse
+from .test_case_responses import TestCaseListItemResponse, TestCaseResponse
 from .test_execution_responses import TestExecutionResponse
-from .test_log_responses import TestLogResponse
+from .test_log_responses import TestLogListItemResponse, TestLogResponse
 
 __all__ = [
     "AgentResponse",
+    "AgentListItemResponse",
     "AgentSummaryResponse",
     "HealthResponse",
     "RegressionTestResponse",
+    "RegressionTestListItemResponse",
     "EvaluationSettingsResponse",
     "TestCaseResponse",
+    "TestCaseListItemResponse",
     "TestExecutionResponse",
     "TestLogResponse",
+    "TestLogListItemResponse",
 ]

--- a/src/api/v1/schemas/responses/agent_responses.py
+++ b/src/api/v1/schemas/responses/agent_responses.py
@@ -28,6 +28,27 @@ class AgentResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AgentListItemResponse(BaseModel):
+    """Light-weight agent payload for collection endpoints."""
+
+    id: str = Field(..., description="Agent identifier")
+    name: str = Field(..., description="Agent name")
+    description: Optional[str] = Field(None, description="Agent description")
+    default_model_name: Optional[str] = Field(
+        None, description="Default model name applied during regression"
+    )
+    default_system_prompt: Optional[str] = Field(
+        None, description="Default system prompt applied during regression"
+    )
+    default_model_settings: Optional[dict] = Field(
+        None, description="Default model settings JSON"
+    )
+    is_deleted: bool = Field(False, description="Soft delete flag")
+    created_at: Optional[datetime] = Field(None, description="Creation timestamp")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class AgentSummaryResponse(BaseModel):
     """Short agent representation for embedding."""
 
@@ -38,4 +59,4 @@ class AgentSummaryResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-__all__ = ["AgentResponse", "AgentSummaryResponse"]
+__all__ = ["AgentResponse", "AgentListItemResponse", "AgentSummaryResponse"]

--- a/src/api/v1/schemas/responses/regression_test_responses.py
+++ b/src/api/v1/schemas/responses/regression_test_responses.py
@@ -43,4 +43,28 @@ class RegressionTestResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-__all__ = ["RegressionTestResponse"]
+class RegressionTestListItemResponse(BaseModel):
+    """Summary payload returned by regression list endpoints."""
+
+    id: str = Field(..., description="Regression test identifier")
+    agent_id: str = Field(..., description="Agent identifier")
+    status: str = Field(..., description="Regression status")
+    model_name_override: str = Field(..., description="Model name override")
+    system_prompt_override: str = Field(..., description="System prompt override")
+    model_settings_override: Dict = Field(..., description="Model settings override")
+    total_count: int = Field(..., description="Total number of executed test cases")
+    passed_count: int = Field(
+        ..., description="Number of test logs evaluated as passed"
+    )
+    declined_count: int = Field(
+        ..., description="Number of test logs evaluated as declined"
+    )
+    created_at: datetime = Field(..., description="Record creation timestamp")
+    agent: Optional[AgentSummaryResponse] = Field(
+        None, description="Summary information about the agent"
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+__all__ = ["RegressionTestResponse", "RegressionTestListItemResponse"]

--- a/src/api/v1/schemas/responses/test_case_responses.py
+++ b/src/api/v1/schemas/responses/test_case_responses.py
@@ -44,3 +44,28 @@ class TestCaseResponse(BaseModel):
     updated_at: datetime = Field(..., description="Last update timestamp")
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class TestCaseListItemResponse(BaseModel):
+    """Summary representation for listing test cases."""
+
+    id: str = Field(..., description="Test case ID")
+    name: str = Field(..., description="Test case name")
+    description: Optional[str] = Field(None, description="Test case description")
+    last_user_message: str = Field(..., description="Last user message")
+    response_example: Optional[str] = Field(
+        None, description="Example LLM response for similarity comparisons"
+    )
+    response_expectation: Optional[str] = Field(
+        None, description="Acceptance criteria or evaluation notes"
+    )
+    agent_id: str = Field(..., description="Owning agent ID")
+    agent: Optional[AgentSummaryResponse] = Field(
+        None, description="Owning agent summary"
+    )
+    created_at: datetime = Field(..., description="Creation timestamp")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+__all__ = ["TestCaseResponse", "TestCaseListItemResponse"]

--- a/src/api/v1/schemas/responses/test_log_responses.py
+++ b/src/api/v1/schemas/responses/test_log_responses.py
@@ -54,3 +54,44 @@ class TestLogResponse(BaseModel):
     created_at: datetime = Field(..., description="Creation timestamp")
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class TestLogListItemResponse(BaseModel):
+    """Trimmed representation for test log listings."""
+
+    id: str = Field(..., description="Test log ID")
+    test_case_id: str = Field(..., description="Associated test case ID")
+    agent_id: str = Field(..., description="Associated agent ID")
+    regression_test_id: Optional[str] = Field(
+        None, description="Regression test identifier if applicable"
+    )
+    model_name: str = Field(..., description="Model used for execution")
+    user_message: str = Field(..., description="User message used")
+    llm_response: Optional[str] = Field(None, description="LLM response text")
+    response_expectation_snapshot: Optional[str] = Field(
+        None, description="Acceptance criteria captured when the log was created"
+    )
+    response_time_ms: Optional[int] = Field(
+        None, description="Response time in milliseconds"
+    )
+    is_passed: Optional[bool] = Field(
+        None,
+        description="Evaluation outcome: true=passed, false=failed, None=unknown",
+    )
+    evaluation_feedback: Optional[str] = Field(
+        None, description="Summary returned by the evaluation agent"
+    )
+    evaluation_model_name: Optional[str] = Field(
+        None, description="Model used by the evaluation agent"
+    )
+    evaluation_metadata: Optional[Dict] = Field(
+        None, description="Structured payload from the evaluation agent"
+    )
+    status: str = Field(..., description="Execution status")
+    error_message: Optional[str] = Field(None, description="Error message if failed")
+    created_at: datetime = Field(..., description="Creation timestamp")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+__all__ = ["TestLogResponse", "TestLogListItemResponse"]

--- a/src/services/regression_test_service.py
+++ b/src/services/regression_test_service.py
@@ -12,9 +12,9 @@ from src.models import RegressionTest
 from src.services.agent_service import AgentService, AgentSummary
 from src.services.test_case_service import TestCaseService
 from src.services.test_execution_service import (
+    ExecutionData,
     ExecutionResult,
     ExecutionService,
-    ExecutionData,
 )
 from src.stores.regression_test_store import RegressionTestStore
 

--- a/static/js/test-cases.js
+++ b/static/js/test-cases.js
@@ -700,7 +700,6 @@ async function createTestCase() {
         const modal = bootstrap.Modal.getInstance(document.getElementById('createTestCaseModal'));
         modal.hide();
         document.getElementById('createTestCaseForm').reset();
-        populateAgentSelects();
 
         // Reload test cases
         loadTestCases(1);

--- a/tests/test_test_execution_service.py
+++ b/tests/test_test_execution_service.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.services.test_execution_service import ExecutionService, ExecutionData
+from src.services.test_execution_service import ExecutionData, ExecutionService
 
 
 class DummyTestCaseService:


### PR DESCRIPTION
- Introduced new list item response converters for agents, regression tests, test cases, and test logs to provide lightweight representations for collection endpoints.
- Updated API endpoints to return the new list item response models, enhancing performance and clarity in responses.
- Refactored relevant import statements and response model definitions to accommodate the new structure.